### PR TITLE
Disable 1.0 and nightly Julia version builds in  CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,9 +19,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          # - '1.0'
           - '1.8'
-          - 'nightly'
+          # - 'nightly'
         os:
           - ubuntu-latest
         arch:


### PR DESCRIPTION
Temporarily disabling running 1.0 and latest version of Julia builds (targeting 1.8 for now). I also manually disabled the documentation build on GitHub (to reverse do `Actions -> Documentation -> Enable workflow`).