### PR TITLE
Minor doctoring update

### DIFF
--- a/src/Library/nutrients.jl
+++ b/src/Library/nutrients.jl
@@ -5,11 +5,11 @@ Modules related to plankton nutrient uptake
 module Nutrients
 
 "
-    N / (kₙ + N)
+    R / (kᵣ + R)
 
-Monod formulation of nutrient limitation, which is based on Michaelis-Menten enzyme kinetics. 
+Monod formulation of nutrient limitation, which is based on Michaelis-Menten enzyme kinetics.
 
-Where: 
+Where:
 R = nutrient (e.g. N, P, Si)
 kᵣ = nutrient half saturation constant
 


### PR DESCRIPTION
The function description in the docstring used `N` and `kₙ` parameters whereas below that `R` and `kᵣ` are used instead.