### PR TITLE
Fix parsing

### DIFF
--- a/src/Models/Dynamic.jl
+++ b/src/Models/Dynamic.jl
@@ -133,33 +133,32 @@ end
 
 
 """
-    parse_expression(f_expr) -> Tuple(Vector, Vector)
+    parse_expression(f_expr) -> Vector
 
-Returns all argument names and methods called in expression.
+Returns all symbols (argument names and method names) called in expression.
 
 # Example
 ```Julia
 parse_expression(:(α * x - β * x * y))
 """
 function parse_expression(f_expr)
-    argnames = []
-    methods = []
+    symbols = []
 
     expressions = [f_expr]
     for exp in expressions
         args = exp.args
-        push!(methods, args[1])
+        push!(symbols, args[1])
         # if the arg isn't a symbol or another expression, it's a value --> ignore
         for arg in args[2:end]
             if typeof(arg) == Expr
                 push!(expressions, arg)
             elseif typeof(arg) == Symbol
-                push!(argnames, arg)
+                push!(symbols, arg)
             end
         end
     end
 
-    return argnames, methods
+    return symbols
 end
 
 
@@ -172,15 +171,10 @@ Checks that all methods and arguments are defined. Specifically:
 If not, throws an UnderVarError.
 """
 function expression_check(params, f_expr; module_name=Dynamic)
-    argnames, methods = parse_expression(f_expr)
-    for arg in argnames
-        if arg ∉ params
-            throw(UndefVarError(arg))
-        end
-    end
-    for m in methods
-        if !isdefined(module_name, m)
-            throw(UndefVarError(m))
+    symbols = parse_expression(f_expr)
+    for s in symbols
+        if s ∉ params && !isdefined(module_name, s)
+            throw(UndefVarError(s))
         end
     end
 end

--- a/src/Models/Dynamic.jl
+++ b/src/Models/Dynamic.jl
@@ -146,10 +146,8 @@ function parse_expression(f_expr)
 
     expressions = [f_expr]
     for exp in expressions
-        args = exp.args
-        push!(symbols, args[1])
         # if the arg isn't a symbol or another expression, it's a value --> ignore
-        for arg in args[2:end]
+        for arg in exp.args
             if typeof(arg) == Expr
                 push!(expressions, arg)
             elseif typeof(arg) == Symbol

--- a/src/Models/Dynamic.jl
+++ b/src/Models/Dynamic.jl
@@ -148,9 +148,9 @@ function parse_expression(f_expr)
     for exp in expressions
         # if the arg isn't a symbol or another expression, it's a value --> ignore
         for arg in exp.args
-            if typeof(arg) == Expr
+            if isa(arg, Expr)
                 push!(expressions, arg)
-            elseif typeof(arg) == Symbol
+            elseif isa(arg, Symbol)
                 push!(symbols, arg)
             end
         end

--- a/test/test_dynamic.jl
+++ b/test/test_dynamic.jl
@@ -27,6 +27,11 @@ using Oceananigans.Biogeochemistry: AbstractContinuousFormBiogeochemistry,
         params = [:sn, :p]
         @test expression_check(params, f_expr) === nothing
 
+        # no errors - use of vectors
+        f_expr = :(sum[a, b, c])
+        params = [:a, :b, :c]
+        @test expression_check(params, f_expr) === nothing
+
     end
 
     @testset "create_bgc_struct" begin


### PR DESCRIPTION
This PR simplifies our expression parsing to make fewer assumptions that should make it more robust.

In the expression args everything is either a symbol (arg or method), a value or another expression. I made the assumption that the first arg is always a method name but this isn't true (e.g., when the expression is a vector). 

So instead the expression parsing function now simply pulls out all the symbols and then we check whether the symbol is defined in our parameter list or whether it is a defined method, if neither then we raise an error.