### PR TITLE
Tidy NPZD formulation

### DIFF
--- a/examples/NPZD_functions.jl
+++ b/examples/NPZD_functions.jl
@@ -1,21 +1,23 @@
-nutrient_limitation(N, kₙ) = N / (kₙ + N)
+menden_limitation(R, k) = R / (k + R) 
 
 Q₁₀(T) = 1.88 ^ (T / 10) # T in °C
 
-light_limitation(PAR, α, μ₀)= α * PAR / sqrt(μ₀ ^ 2 + α ^ 2 * PAR ^ 2)
+smith_light_limitation(PAR, α, μ₀)= α * PAR / sqrt(μ₀ ^ 2 + α ^ 2 * PAR ^ 2)
 
-phytoplankton_metabolic_loss(P, lᵖⁿ) = lᵖⁿ  * P
+remineralization(D, r) = r * D
 
-zooplankton_metabolic_loss(Z, lᶻⁿ) = lᶻⁿ  * Z
+photosynthetic_growth(N, P, PAR, μ₀, kₙ, α) = μ₀ * menden_limitation(N, kₙ) * smith_light_limitation(PAR, α, μ₀) * P
 
-remineralization(D, rᵈⁿ) = rᵈⁿ * D
+predation_loss(P, Z, gₘₐₓ, kₚ) = gₘₐₓ * menden_limitation(P ^ 2, kₚ ^ 2) * Z
 
-phytoplankton_growth(N, P, PAR, μ₀, kₙ, α) = μ₀ * nutrient_limitation(N, kₙ) * light_limitation(PAR, α, μ₀) * P
-phytoplankton_grazing_loss(P, Z, gₘₐₓ, kₚ) = gₘₐₓ * nutrient_limitation(P ^ 2, kₚ ^ 2) * Z
-phytoplankton_mortality_loss(P, lᵖᵈ) = lᵖᵈ * P
+predation_gain(P, Z, β, gₘₐₓ, kₚ) = β * gₘₐₓ * menden_limitation(P ^ 2, kₚ ^ 2) * Z
 
-zooplankton_grazing_gain(P, Z, β, gₘₐₓ, kₚ) = β * gₘₐₓ * nutrient_limitation(P ^ 2, kₚ ^ 2) * Z
-zooplankton_mortality_loss(Z, lᶻᵈ) = lᶻᵈ * Z ^ 2
-zooplankton_assimilation_loss(P, Z, β, gₘₐₓ, kₚ) = (1 - β) * gₘₐₓ * nutrient_limitation(P ^ 2, kₚ ^ 2) * Z
+predation_assimilation_loss(P, Z, β, gₘₐₓ, kₚ) = (1 - β) * gₘₐₓ * menden_limitation(P ^ 2, kₚ ^ 2) * Z
+
+linear_loss(P, l) = l  * P
+
+quadratic_loss(P, l) = l  * P ^ 2
 
 dummy_gmax_function(gₘₐₓ, a, b) = ((gₘₐₓ*a) + b-b)/a # this will always return gₘₐₓ
+
+

--- a/examples/NPZD_functions.jl
+++ b/examples/NPZD_functions.jl
@@ -17,7 +17,3 @@ predation_assimilation_loss(P, Z, β, gₘₐₓ, kₚ) = (1 - β) * gₘₐₓ 
 linear_loss(P, l) = l  * P
 
 quadratic_loss(P, l) = l  * P ^ 2
-
-dummy_gmax_function(gₘₐₓ, a, b) = ((gₘₐₓ*a) + b-b)/a # this will always return gₘₐₓ
-
-

--- a/test/test_dynamic.jl
+++ b/test/test_dynamic.jl
@@ -108,24 +108,24 @@ using Oceananigans.Biogeochemistry: AbstractContinuousFormBiogeochemistry,
             aux_field_vars = [:PAR]
 
             tracers = Dict(
-                "N" => :(phytoplankton_metabolic_loss(P, lᵖⁿ)
-                + zooplankton_metabolic_loss(Z, lᶻⁿ)
+                "N" => :(linear_loss(P, lᵖⁿ)
+                + linear_loss(Z, lᶻⁿ)
                 + remineralization(D, rᵈⁿ)
-                - phytoplankton_growth(N, P, PAR, μ₀, kₙ, α)),
+                - photosynthetic_growth(N, P, PAR, μ₀, kₙ, α)),
 
-                "D" => :(phytoplankton_mortality_loss(P, lᵖᵈ)
-                + zooplankton_assimilation_loss(P, Z, β, gₘₐₓ, kₚ)
-                + zooplankton_mortality_loss(Z, lᶻᵈ)
+                "D" => :(linear_loss(P, lᵖᵈ)
+                + predation_assimilation_loss(P, Z, β, gₘₐₓ, kₚ)
+                + quadratic_loss(Z, lᶻᵈ)
                 - remineralization(D, rᵈⁿ)),
 
-                "P" => :(phytoplankton_growth(N, P, PAR, μ₀, kₙ, α)
-                - phytoplankton_grazing_loss(P, Z, gₘₐₓ, kₚ)
-                - phytoplankton_metabolic_loss(P, lᵖⁿ)
-                - phytoplankton_mortality_loss(P, lᵖᵈ)),
+                "P" => :(photosynthetic_growth(N, P, PAR, μ₀, kₙ, α)
+                - predation_loss(P, Z, gₘₐₓ, kₚ)
+                - linear_loss(P, lᵖⁿ)
+                - linear_loss(P, lᵖᵈ)),
 
-                "Z" => :(zooplankton_grazing_gain(P, Z, β, gₘₐₓ, kₚ)
-                - zooplankton_metabolic_loss(Z, lᶻⁿ)
-                - zooplankton_mortality_loss(Z, lᶻᵈ))
+                "Z" => :(predation_gain(P, Z, β, gₘₐₓ, kₚ)
+                - linear_loss(Z, lᶻⁿ)
+                - quadratic_loss(Z, lᶻᵈ))
             )
 
             NPZD = create_bgc_struct(:NPZD, parameters)


### PR DESCRIPTION
Removed some repetitive functions
```
phytoplankton_mortality_loss(P, lᵖᵈ) = lᵖᵈ * P
zooplankton_metabolic_loss(Z, lᶻⁿ) = lᶻⁿ  * Z
phytoplankton_metabolic_loss(P, lᵖⁿ) = lᵖⁿ  * P
```
now:
```
linear_loss(P, l) = l * P
```

Changed "grazing" to predation, and renamed nutrient and light limitation to authors associated with form (e.g. Menden_limitation and Smith_light_limitation).



