### PR TITLE
Update PAR options in box model

### DIFF
--- a/src/Library/light.jl
+++ b/src/Library/light.jl
@@ -10,11 +10,12 @@ using Oceananigans.Units
 const year = years = 365day
 
 """
-    cyclical_PAR(t, z) -> Float
+    cyclical_PAR(t, parameters) -> Float
 
-Time-dependent cyclical PAR at depth z (suitable for use with box models).
+Time-dependent cyclical PAR at depth defined in `parameters` (suitable for use with box models).
 """
-function cyclical_PAR(t; z=-10)
+function cyclical_PAR(t, parameters=[-10])
+    z = parameters[1]
     PAR⁰ =
         60 *
         (1 - cos((t + 15days) * 2π / year)) *
@@ -24,4 +25,4 @@ end
 
 export cyclical_PAR
 
-end # module
+end # modulePAR

--- a/src/Library/light.jl
+++ b/src/Library/light.jl
@@ -19,7 +19,7 @@ function cyclical_PAR(t, parameters)
         60 *
         (1 - cos((t + 15days) * 2π / year)) *
         (1 / (1 + 0.2 * exp(-((mod(t, year) - 200days) / 50days)^2))) + 2
-    return PAR⁰ * exp(0.2parameters.z)
+    return PAR⁰ * exp(0.2 * parameters.z)
 end
 
 export cyclical_PAR

--- a/src/Library/light.jl
+++ b/src/Library/light.jl
@@ -25,4 +25,4 @@ end
 
 export cyclical_PAR
 
-end # modulePAR
+end # module

--- a/src/Library/light.jl
+++ b/src/Library/light.jl
@@ -12,10 +12,9 @@ const year = years = 365day
 """
     cyclical_PAR(t, parameters) -> Float
 
-Time-dependent cyclical PAR at depth defined in `parameters` (suitable for use with box models).
+Time-dependent cyclical PAR at depth `z` (suitable for use with box models).
 """
-function cyclical_PAR(t, parameters=[-10])
-    z = parameters[1]
+function cyclical_PAR(t, z=-10)
     PAR⁰ =
         60 *
         (1 - cos((t + 15days) * 2π / year)) *

--- a/src/Library/light.jl
+++ b/src/Library/light.jl
@@ -12,14 +12,14 @@ const year = years = 365day
 """
     cyclical_PAR(t, parameters) -> Float
 
-Time-dependent cyclical PAR at depth `z` (suitable for use with box models).
+Time-dependent cyclical PAR at depth `parameters.z` (suitable for use with box models).
 """
-function cyclical_PAR(t, z=-10)
+function cyclical_PAR(t, parameters)
     PAR⁰ =
         60 *
         (1 - cos((t + 15days) * 2π / year)) *
         (1 / (1 + 0.2 * exp(-((mod(t, year) - 200days) / 50days)^2))) + 2
-    return PAR⁰ * exp(0.2z)
+    return PAR⁰ * exp(0.2parameters.z)
 end
 
 export cyclical_PAR

--- a/src/box_model.jl
+++ b/src/box_model.jl
@@ -24,16 +24,22 @@ Create an OceanBioME.BoxModel object and set initial values.
 - `bgc_model`: biogeochemistry model, a subtype of AbstractContinuousFormBiogeochemistry,
     e.g., returned by `Agate.create_bgc_struct()`
 - `init_conditions`: NamedTuple of initial values
+
+# Keywords
 - `PAR_f`: a time dependant PAR function (defaults to `Agate.Library.Light.cyclical_PAR`)
 """
 function create_box_model(bgc_model, init_conditions; PAR_f=cyclical_PAR)
     grid = BoxModelGrid() # 1x1x1 grid
     clock = Clock(; time=zero(grid))
-    PAR = FunctionField{Center,Center,Center}(PAR_f, grid; clock)
 
-    biogeochemistry = Biogeochemistry(
-        bgc_model; light_attenuation=PrescribedPhotosyntheticallyActiveRadiation(PAR)
-    )
+    if isnothing(PAR_f)
+        light_attenuation = nothing
+    else
+        PAR = FunctionField{Center,Center,Center}(PAR_f, grid; clock)
+        light_attenuation = PrescribedPhotosyntheticallyActiveRadiation(PAR)
+    end
+
+    biogeochemistry = Biogeochemistry(bgc_model; light_attenuation=light_attenuation)
 
     model = BoxModel(; biogeochemistry, clock)
     set!(model, init_conditions)
@@ -53,22 +59,24 @@ Returns timeseries for each tracer of the form (<tracer name>: [<value at t1>, .
 - `init_conditions`: NamedTuple of initial values
 
 # Keywords
-- Δt: simulation step time
-- stop_time: until when to run the simulation
-- save_interval: interval at which to save simulation results
-- filename: name of file to save results to
-- overwrite: whether to overwrite existing files
+- `PAR_f`: a time dependant PAR function (defaults to `Agate.Library.Light.cyclical_PAR`)
+- `Δt``: simulation step time
+- `stop_time`: until when to run the simulation
+- `save_interval`: interval at which to save simulation results
+- `filename`: name of file to save results to
+- `overwrite`: whether to overwrite existing files
 """
 function run_box_model(
     bgc_model,
     init_conditions;
+    PAR_f=cyclical_PAR,
     Δt=5minutes,
     stop_time=3years,
     save_interval=1day,
     filename="box.jld2",
     overwrite=true,
 )
-    model = create_box_model(bgc_model, init_conditions)
+    model = create_box_model(bgc_model, init_conditions; PAR_f=PAR_f)
 
     simulation = Simulation(model; Δt=Δt, stop_time=stop_time)
     simulation.output_writers[:fields] = JLD2OutputWriter(

--- a/src/box_model.jl
+++ b/src/box_model.jl
@@ -29,7 +29,8 @@ Create an OceanBioME.BoxModel object and set initial values.
 
 # Keywords
 - `PAR_f`: a time dependant PAR function (defaults to `Agate.Library.Light.cyclical_PAR`)
-- `PAR_parameters`: any fixed parameters of the PAR function (e.g., depth `z`) passed as NamedTuple
+- `PAR_parameters`: any fixed parameters of the PAR function (e.g., depth `z`) passed as a
+   NamedTuple (set to `nothing` if there are none)
 """
 function create_box_model(
     bgc_model, init_conditions; PAR_f=cyclical_PAR, PAR_parameters=(; z=-10)
@@ -66,7 +67,8 @@ Returns timeseries for each tracer of the form (<tracer name>: [<value at t1>, .
 
 # Keywords
 - `PAR_f`: a time dependant PAR function (defaults to `Agate.Library.Light.cyclical_PAR`)
-- `PAR_parameters`: any fixed parameters of the PAR function (e.g., depth `z`) passed as NamedTuple
+- `PAR_parameters`: any fixed parameters of the PAR function (e.g., depth `z`) passed as a
+   NamedTuple (set to `nothing` if there are none)
 - `Δt``: simulation step time
 - `stop_time`: until when to run the simulation
 - `save_interval`: interval at which to save simulation results

--- a/src/box_model.jl
+++ b/src/box_model.jl
@@ -16,7 +16,7 @@ export create_box_model, run_box_model
 const year = years = 365day
 
 """
-    create_box_model(bgc_model, init_conditions, PAR_f, parameters) -> OceanBioME.BoxModel
+    create_box_model(bgc_model, init_conditions, PAR_f, z) -> OceanBioME.BoxModel
 
 Create an OceanBioME.BoxModel object and set initial values.
 

--- a/src/box_model.jl
+++ b/src/box_model.jl
@@ -28,14 +28,13 @@ Create an OceanBioME.BoxModel object and set initial values.
 # Keywords
 - `PAR_f`: a time dependant PAR function (defaults to `Agate.Library.Light.cyclical_PAR`)
 """
-function create_box_model(bgc_model, init_conditions; PAR_f=cyclical_PAR)
+function create_box_model(bgc_model, init_conditions; PAR_f=cyclical_PAR, parameters=[-10])
     grid = BoxModelGrid() # 1x1x1 grid
     clock = Clock(; time=zero(grid))
-
     if isnothing(PAR_f)
         light_attenuation = nothing
     else
-        PAR = FunctionField{Center,Center,Center}(PAR_f, grid; clock)
+        PAR = FunctionField{Center,Center,Center}(PAR_f, grid; clock, parameters)
         light_attenuation = PrescribedPhotosyntheticallyActiveRadiation(PAR)
     end
 
@@ -60,6 +59,7 @@ Returns timeseries for each tracer of the form (<tracer name>: [<value at t1>, .
 
 # Keywords
 - `PAR_f`: a time dependant PAR function (defaults to `Agate.Library.Light.cyclical_PAR`)
+- `PAR_parameters`: any addditional parameters of the PAR function (e.g., depth)
 - `Δt``: simulation step time
 - `stop_time`: until when to run the simulation
 - `save_interval`: interval at which to save simulation results
@@ -70,13 +70,16 @@ function run_box_model(
     bgc_model,
     init_conditions;
     PAR_f=cyclical_PAR,
+    PAR_parameters=[-10],
     Δt=5minutes,
     stop_time=3years,
     save_interval=1day,
     filename="box.jld2",
     overwrite=true,
 )
-    model = create_box_model(bgc_model, init_conditions; PAR_f=PAR_f)
+    model = create_box_model(
+        bgc_model, init_conditions; PAR_f=PAR_f, parameters=PAR_parameters
+    )
 
     simulation = Simulation(model; Δt=Δt, stop_time=stop_time)
     simulation.output_writers[:fields] = JLD2OutputWriter(

--- a/src/box_model.jl
+++ b/src/box_model.jl
@@ -16,7 +16,9 @@ export create_box_model, run_box_model
 const year = years = 365day
 
 """
-    create_box_model(bgc_model, init_conditions, PAR_f, z) -> OceanBioME.BoxModel
+    create_box_model(
+        bgc_model, init_conditions; PAR_f=cyclical_PAR, PAR_parameters=(; z=-10)
+    ) -> OceanBioME.BoxModel
 
 Create an OceanBioME.BoxModel object and set initial values.
 
@@ -27,10 +29,10 @@ Create an OceanBioME.BoxModel object and set initial values.
 
 # Keywords
 - `PAR_f`: a time dependant PAR function (defaults to `Agate.Library.Light.cyclical_PAR`)
-- `PAR_parameters`: any fixed parameters of the PAR function (e.g., depth)
+- `PAR_parameters`: any fixed parameters of the PAR function (e.g., depth `z`) passed as NamedTuple
 """
 function create_box_model(
-    bgc_model, init_conditions; PAR_f=cyclical_PAR, PAR_parameters=-10
+    bgc_model, init_conditions; PAR_f=cyclical_PAR, PAR_parameters=(; z=-10)
 )
     grid = BoxModelGrid() # 1x1x1 grid
     clock = Clock(; time=zero(grid))
@@ -64,7 +66,7 @@ Returns timeseries for each tracer of the form (<tracer name>: [<value at t1>, .
 
 # Keywords
 - `PAR_f`: a time dependant PAR function (defaults to `Agate.Library.Light.cyclical_PAR`)
-- `PAR_parameters`: any fixed parameters of the PAR function (e.g., depth)
+- `PAR_parameters`: any fixed parameters of the PAR function (e.g., depth `z`) passed as NamedTuple
 - `Δt``: simulation step time
 - `stop_time`: until when to run the simulation
 - `save_interval`: interval at which to save simulation results
@@ -75,7 +77,7 @@ function run_box_model(
     bgc_model,
     init_conditions;
     PAR_f=cyclical_PAR,
-    PAR_parameters=-10,
+    PAR_parameters=(; z=-10),
     Δt=5minutes,
     stop_time=3years,
     save_interval=1day,

--- a/src/box_model.jl
+++ b/src/box_model.jl
@@ -16,7 +16,7 @@ export create_box_model, run_box_model
 const year = years = 365day
 
 """
-    create_box_model(bgc_model, init_conditions, PAR_f) -> OceanBioME.BoxModel
+    create_box_model(bgc_model, init_conditions, PAR_f, parameters) -> OceanBioME.BoxModel
 
 Create an OceanBioME.BoxModel object and set initial values.
 
@@ -27,6 +27,7 @@ Create an OceanBioME.BoxModel object and set initial values.
 
 # Keywords
 - `PAR_f`: a time dependant PAR function (defaults to `Agate.Library.Light.cyclical_PAR`)
+- `parameters`: any fixed parameters of the PAR function (e.g., depth) passed as an Array
 """
 function create_box_model(bgc_model, init_conditions; PAR_f=cyclical_PAR, parameters=[-10])
     grid = BoxModelGrid() # 1x1x1 grid
@@ -59,11 +60,11 @@ Returns timeseries for each tracer of the form (<tracer name>: [<value at t1>, .
 
 # Keywords
 - `PAR_f`: a time dependant PAR function (defaults to `Agate.Library.Light.cyclical_PAR`)
-- `PAR_parameters`: any addditional parameters of the PAR function (e.g., depth)
+- `PAR_parameters`: any fixed parameters of the PAR function (e.g., depth) passed as an Array
 - `Δt``: simulation step time
 - `stop_time`: until when to run the simulation
 - `save_interval`: interval at which to save simulation results
-- `filename`: name of file to save results to
+- `filename`: name of file to save simulation results to
 - `overwrite`: whether to overwrite existing files
 """
 function run_box_model(
@@ -100,12 +101,12 @@ function run_box_model(
 end
 
 """
-    set!(model::BoxModel, init_conditions) -> nothing
+    set!(model::BoxModel, init_conditions::NamedTuple)
 
 Set the `BoxModel` initial conditions (Field values).
 
 # Arguments
-- `model` - the model to set the arguments for
+- `model`: the model to set the arguments for
 - `init_conditions`: NamedTuple of initial values
 """
 function set!(model::BoxModel, init_conditions::NamedTuple)

--- a/src/box_model.jl
+++ b/src/box_model.jl
@@ -27,15 +27,19 @@ Create an OceanBioME.BoxModel object and set initial values.
 
 # Keywords
 - `PAR_f`: a time dependant PAR function (defaults to `Agate.Library.Light.cyclical_PAR`)
-- `parameters`: any fixed parameters of the PAR function (e.g., depth) passed as an Array
+- `PAR_parameters`: any fixed parameters of the PAR function (e.g., depth)
 """
-function create_box_model(bgc_model, init_conditions; PAR_f=cyclical_PAR, parameters=[-10])
+function create_box_model(
+    bgc_model, init_conditions; PAR_f=cyclical_PAR, PAR_parameters=-10
+)
     grid = BoxModelGrid() # 1x1x1 grid
     clock = Clock(; time=zero(grid))
     if isnothing(PAR_f)
         light_attenuation = nothing
     else
-        PAR = FunctionField{Center,Center,Center}(PAR_f, grid; clock, parameters)
+        PAR = FunctionField{Center,Center,Center}(
+            PAR_f, grid; clock, parameters=PAR_parameters
+        )
         light_attenuation = PrescribedPhotosyntheticallyActiveRadiation(PAR)
     end
 
@@ -60,7 +64,7 @@ Returns timeseries for each tracer of the form (<tracer name>: [<value at t1>, .
 
 # Keywords
 - `PAR_f`: a time dependant PAR function (defaults to `Agate.Library.Light.cyclical_PAR`)
-- `PAR_parameters`: any fixed parameters of the PAR function (e.g., depth) passed as an Array
+- `PAR_parameters`: any fixed parameters of the PAR function (e.g., depth)
 - `Δt``: simulation step time
 - `stop_time`: until when to run the simulation
 - `save_interval`: interval at which to save simulation results
@@ -71,7 +75,7 @@ function run_box_model(
     bgc_model,
     init_conditions;
     PAR_f=cyclical_PAR,
-    PAR_parameters=[-10],
+    PAR_parameters=-10,
     Δt=5minutes,
     stop_time=3years,
     save_interval=1day,
@@ -79,7 +83,7 @@ function run_box_model(
     overwrite=true,
 )
     model = create_box_model(
-        bgc_model, init_conditions; PAR_f=PAR_f, parameters=PAR_parameters
+        bgc_model, init_conditions; PAR_f=PAR_f, PAR_parameters=PAR_parameters
     )
 
     simulation = Simulation(model; Δt=Δt, stop_time=stop_time)

--- a/test/test_box_model.jl
+++ b/test/test_box_model.jl
@@ -8,44 +8,56 @@ using Oceananigans.Fields: FunctionField
 
 const year = years = 365day
 
-@testset "NPZD box model" begin
-
-    # ==================================================
-    # Agate NPZD model
-    # ==================================================
-
+@testset "box_model" begin
     include("../examples/NPZD/model.jl")
     npzd_model = NPZD()
     init_conditions = (N=7.0, P=0.01, Z=0.05, D=0.0)
-    agate_box_model = create_box_model(npzd_model, init_conditions)
 
-    # ==================================================
-    # OceanBioME NPZD model
-    # ==================================================
-    grid = BoxModelGrid()
-    clock = Clock(; time=zero(grid))
-    PAR = FunctionField{Center,Center,Center}(cyclical_PAR, grid; clock)
+    @testset "PAR parameters" begin
+        agate_box_model = create_box_model(npzd_model, init_conditions)
+        @test agate_box_model.biogeochemistry.light_attenuation.fields[1][1, 1, 1] ===
+            0.5398701925529049
 
-    biogeochemistry = NutrientPhytoplanktonZooplanktonDetritus(;
-        grid,
-        light_attenuation_model=PrescribedPhotosyntheticallyActiveRadiation(PAR),
-        # this is probably not necessary but ensuring consistency here
-        sinking_speeds=NamedTuple(),
-    )
-    oceanbiome_box_model = BoxModel(; biogeochemistry, clock)
-    set!(oceanbiome_box_model; N=7, P=0.01, Z=0.05, D=0.0)
+        agate_box_model = create_box_model(npzd_model, init_conditions; PAR_parameters=-5)
+        @test agate_box_model.biogeochemistry.light_attenuation.fields[1][1, 1, 1] ===
+            1.4675193341432473
+    end
 
-    # ==================================================
-    # Compare
-    # ==================================================
+    @testset "NPZD box model" begin
 
-    Δt = 1day
-    for i in range(1, 1000)
-        time_step!(oceanbiome_box_model, Δt)
-        time_step!(agate_box_model, Δt)
-        if mod(i, 10) == 0
-            @test agate_box_model.fields.P.data[1, 1, 1] ===
-                oceanbiome_box_model.fields.P.data[1, 1, 1]
+        # ==================================================
+        # Agate NPZD model
+        # ==================================================
+        agate_box_model = create_box_model(npzd_model, init_conditions)
+
+        # ==================================================
+        # OceanBioME NPZD model
+        # ==================================================
+        grid = BoxModelGrid()
+        clock = Clock(; time=zero(grid))
+        PAR = FunctionField{Center,Center,Center}(cyclical_PAR, grid; clock)
+
+        biogeochemistry = NutrientPhytoplanktonZooplanktonDetritus(;
+            grid,
+            light_attenuation_model=PrescribedPhotosyntheticallyActiveRadiation(PAR),
+            # this is probably not necessary but ensuring consistency here
+            sinking_speeds=NamedTuple(),
+        )
+        oceanbiome_box_model = BoxModel(; biogeochemistry, clock)
+        set!(oceanbiome_box_model; N=7, P=0.01, Z=0.05, D=0.0)
+
+        # ==================================================
+        # Compare
+        # ==================================================
+
+        Δt = 1day
+        for i in range(1, 1000)
+            time_step!(oceanbiome_box_model, Δt)
+            time_step!(agate_box_model, Δt)
+            if mod(i, 10) == 0
+                @test agate_box_model.fields.P.data[1, 1, 1] ===
+                    oceanbiome_box_model.fields.P.data[1, 1, 1]
+            end
         end
     end
 end

--- a/test/test_box_model.jl
+++ b/test/test_box_model.jl
@@ -24,7 +24,7 @@ const year = years = 365day
     # ==================================================
     grid = BoxModelGrid()
     clock = Clock(; time=zero(grid))
-    PAR = FunctionField{Center,Center,Center}(cyclical_PAR, grid; clock, parameters=[-10])
+    PAR = FunctionField{Center,Center,Center}(cyclical_PAR, grid; clock)
 
     biogeochemistry = NutrientPhytoplanktonZooplanktonDetritus(;
         grid,

--- a/test/test_box_model.jl
+++ b/test/test_box_model.jl
@@ -18,7 +18,9 @@ const year = years = 365day
         @test agate_box_model.biogeochemistry.light_attenuation.fields[1][1, 1, 1] ===
             0.5398701925529049
 
-        agate_box_model = create_box_model(npzd_model, init_conditions; PAR_parameters=-5)
+        agate_box_model = create_box_model(
+            npzd_model, init_conditions; PAR_parameters=(; z=-5)
+        )
         @test agate_box_model.biogeochemistry.light_attenuation.fields[1][1, 1, 1] ===
             1.4675193341432473
     end
@@ -35,7 +37,9 @@ const year = years = 365day
         # ==================================================
         grid = BoxModelGrid()
         clock = Clock(; time=zero(grid))
-        PAR = FunctionField{Center,Center,Center}(cyclical_PAR, grid; clock)
+        PAR = FunctionField{Center,Center,Center}(
+            cyclical_PAR, grid; clock, parameters=(; z=-10)
+        )
 
         biogeochemistry = NutrientPhytoplanktonZooplanktonDetritus(;
             grid,

--- a/test/test_box_model.jl
+++ b/test/test_box_model.jl
@@ -24,7 +24,7 @@ const year = years = 365day
     # ==================================================
     grid = BoxModelGrid()
     clock = Clock(; time=zero(grid))
-    PAR = FunctionField{Center,Center,Center}(cyclical_PAR, grid; clock)
+    PAR = FunctionField{Center,Center,Center}(cyclical_PAR, grid; clock, parameters=[-10])
 
     biogeochemistry = NutrientPhytoplanktonZooplanktonDetritus(;
         grid,


### PR DESCRIPTION
Overview:
- Added option to box_model to have no PAR. 
- The PAR function was only passed to the `create_box_model` but not the `run_box_model` function so this has been fixed.
- The user can specify depth of the PAR function used in the box model (this could include other parameters for more complex PAR functions)