### PR TITLE
update parsing issue

### DIFF
--- a/examples/NPZD/functions.jl
+++ b/examples/NPZD/functions.jl
@@ -21,3 +21,5 @@ end
 linear_loss(P, l) = l * P
 
 quadratic_loss(P, l) = l * P^2
+
+summed_linear_loss(P, l) = sum([linear_loss(P[i], l[i]) for i in eachindex(P)])

--- a/examples/NPZD/model.jl
+++ b/examples/NPZD/model.jl
@@ -12,6 +12,7 @@ parameters = (
     kₚ=0.5573,
     β=0.9116,
     lᶻᵈ=0.3395 / day,
+    lⁿ = [0.066, 0.0102]/day,  #[ᵖⁿ, lᶻⁿ]
     rᵈⁿ=0.1213 / day,
     α=0.1953 / day,
 )
@@ -19,7 +20,8 @@ aux_field_vars = [:PAR]
 
 tracers = Dict(
     "N" => :(
-        linear_loss(P, lᵖⁿ) + linear_loss(Z, lᶻⁿ) + remineralization(D, rᵈⁿ) -
+        summed_linear_loss([P, Z], lⁿ) + 
+        remineralization(D, rᵈⁿ) -
         photosynthetic_growth(N, P, PAR, μ₀, kₙ, α)
     ),
     "D" => :(


### PR DESCRIPTION
`summed_linear_loss([P, Z], lⁿ)`

currently results in the error:

` UndefVarError: P not defined`

closes:

[#51](https://github.com/agate-model/Agate.jl/issues/51)
