### PR TITLE
Use joinpath instead of hardcoding file paths

### DIFF
--- a/examples/box_model.jl
+++ b/examples/box_model.jl
@@ -8,7 +8,8 @@ using Plots
 # Define BGC model (NPZD)
 # ==================================================
 
-include("NPZD/model.jl")
+model_path = joinpath("NPZD", "model.jl")
+include(model_path)
 model = NPZD()
 
 # ==================================================

--- a/examples/differential_equations.jl
+++ b/examples/differential_equations.jl
@@ -14,7 +14,8 @@ const year = years = 365day
 # Define BGC model (NPZD)
 # ==================================================
 
-include("NPZD/model.jl")
+model_path = joinpath("NPZD", "model.jl")
+include(model_path)
 model = NPZD()
 
 # ==================================================
@@ -26,7 +27,7 @@ function model_ODEs(du, u, p, t)
 
     # NOTE: in more complex examples there might be other auxiliary fields that should be
     # calculated here and passed to the function below
-    PAR = cyclical_PAR(t)
+    PAR = cyclical_PAR(t, (; z=-10))
 
     for (i, tracer) in enumerate(tracers)
         du[i] = model(Val(tracer), 0, 0, 0, t, u..., PAR)

--- a/test/test_box_model.jl
+++ b/test/test_box_model.jl
@@ -9,7 +9,9 @@ using Oceananigans.Fields: FunctionField
 const year = years = 365day
 
 @testset "box_model" begin
-    include("../examples/NPZD/model.jl")
+    model_path = joinpath("..", "examples", "NPZD", "model.jl")
+    include(model_path)
+
     npzd_model = NPZD()
     init_conditions = (N=7.0, P=0.01, Z=0.05, D=0.0)
 


### PR DESCRIPTION
Closes #59 

This should make it possible to run examples on any system (e.g., Mac, Windows) without the user needing to change anything.