### PR TITLE
Add output files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,14 @@
 /Manifest.toml
+
+# Documenter.jl
 docs/build/
+
+# Model output
+*.jld
+*.jld2
+
+# Plots
+*.png
+*.svg
+*.gif
+*.mp4


### PR DESCRIPTION
This is to make sure we don't accidentally commit any output files. The motivation here is particularly the files that store simulation results as I suspect these can get pretty large and we don't want them in the repo history.