### PR TITLE
Add BGC to ODE wrapper function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,15 +3,16 @@ uuid = "41889b7c-c35c-4f16-abd7-94b299d9fd29"
 version = "0.0.1"
 
 [deps]
-DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
 OceanBioME = "a49af516-9db8-4be4-be45-1dad61c5a376"
 Oceananigans = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
+OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 OceanBioME = "0.11"
+OrdinaryDiffEq = "6.90.1"
 julia = "1.9"
 
 [extras]

--- a/examples/NPZD/tracers.jl
+++ b/examples/NPZD/tracers.jl
@@ -12,14 +12,13 @@ parameters = (
     kₚ=0.5573,
     β=0.9116,
     lᶻᵈ=0.3395 / day,
-    lⁿ=[0.066, 0.0102] / day,  #[lᵖⁿ, lᶻⁿ]
     rᵈⁿ=0.1213 / day,
     α=0.1953 / day,
 )
 
 tracers = Dict(
     "N" => :(
-        summed_linear_loss([P, Z], lⁿ) + remineralization(D, rᵈⁿ) -
+        linear_loss(P, lᵖⁿ) + linear_loss(Z, lᶻⁿ) + remineralization(D, rᵈⁿ) -
         photosynthetic_growth(N, P, PAR, μ₀, kₙ, α)
     ),
     "D" => :(

--- a/examples/differential_equations.jl
+++ b/examples/differential_equations.jl
@@ -2,6 +2,7 @@
 using Agate
 using Agate.Library.Light
 
+using OrdinaryDiffEq
 using Plots
 
 using Oceananigans.Units

--- a/examples/differential_equations.jl
+++ b/examples/differential_equations.jl
@@ -22,6 +22,7 @@ include(joinpath("NPZD", "tracers.jl"))
 init_conditions = (N=7.0, P=0.01, Z=0.05, D=0.0)
 tspan = (0.0, 3years)
 
+# will use default parameter values unless otherwise specified
 prob = bgc_to_ode(NPZD, cyclical_PAR(; z=-10), init_conditions, tspan)
 
 sol = solve(prob, Tsit5())

--- a/examples/inference_hmc.jl
+++ b/examples/inference_hmc.jl
@@ -5,7 +5,7 @@
 using Agate
 using Agate.Library.Light
 
-using DifferentialEquations
+using OrdinaryDiffEq
 using LinearAlgebra
 using Plots
 using StatsPlots

--- a/examples/inference_hmc.jl
+++ b/examples/inference_hmc.jl
@@ -41,10 +41,9 @@ function NPZD_problem(du, u, p, t)
     kₚ = 0.5573
     β = 0.9116
     lᶻᵈ = 0.3395 / day
-    lⁿ = [0.066, 0.0102] / day
     rᵈⁿ = 0.1213 / day
 
-    model = NPZD(μ₀, kₙ, lᵖⁿ, lᶻⁿ, lᵖᵈ, gₘₐₓ, kₚ, β, lᶻᵈ, lⁿ, rᵈⁿ, α)
+    model = NPZD(μ₀, kₙ, lᵖⁿ, lᶻⁿ, lᵖᵈ, gₘₐₓ, kₚ, β, lᶻᵈ, rᵈⁿ, α)
 
     PAR = cyclical_PAR(-10, t)
 

--- a/examples/inference_hmc.jl
+++ b/examples/inference_hmc.jl
@@ -32,8 +32,7 @@ include(joinpath("NPZD", "tracers.jl"))
 
 init_conditions = (Z=0.05, P=0.01, N=7.0, D=0.0)
 # specify which parameters to do inference for (if not all)
-# should we be passing values here too ?!  the user might
-# not always want to stick to the BGC defaults
+# parameter values will be passed when sampled during inference
 params = (:μ₀, :kₙ, :lᵖᵈ, :α)
 tspan = (0.0, stop_time)
 

--- a/src/Agate.jl
+++ b/src/Agate.jl
@@ -2,9 +2,11 @@ module Agate
 
 include("Library/Library.jl")
 include("Models/Models.jl")
+include("bgc_to_ode.jl")
 
 using .Models
 
 export define_tracer_functions
+export bgc_to_ode
 
 end # module

--- a/src/Models/Dynamic.jl
+++ b/src/Models/Dynamic.jl
@@ -96,7 +96,7 @@ end
 """
     add_bgc_methods!(bgc_type, tracers, auxiliary_fields=[], helper_functions=()) -> DataType
 
-Add methods to bgc_type required of AbstractContinuousFormBiogeochemistry:
+Add methods to bgc_type required of Oceananigans.Biogeochemistry:
     - `required_biogeochemical_tracers`
     - `required_biogeochemical_auxiliary_fields`
     - a method per tracer
@@ -104,7 +104,7 @@ WARNING: `biogeochenical_auxiliary_fields` must also be defined to make use of a
 fields. This method is added when OceanBioME.Biogeochemistry(bgc_type()) is instantiated.
 
 # Arguments
-- `bgc_type`: subtype of AbstractContinuousFormBiogeochemistry (returned by `create_bgc_struct`)
+- `bgc_type`: subtype of Oceananigans.Biogeochemistry (returned by `create_bgc_struct`)
 - `tracers`: dictionary of the form (<name> => <expression>, ...)
 
 # Keywords

--- a/src/bgc_to_ode.jl
+++ b/src/bgc_to_ode.jl
@@ -1,0 +1,27 @@
+using DifferentialEquations
+
+using Oceananigans.Biogeochemistry: required_biogeochemical_tracers
+
+function bgc_to_ode(biogeochemistry, PAR_f, init_conditions, tspan, p=nothing)
+    model = biogeochemistry()
+    tracers = required_biogeochemical_tracers(model)
+
+    function modelODE!(du, u, p, t)
+        model = biogeochemistry(p...)
+
+        PAR = PAR_f(t)
+        for (i, tracer) in enumerate(tracers)
+            du[i] = model(Val(tracer), 0, 0, 0, t, u..., PAR)
+        end
+    end
+
+    u0 = [eval(:($init_conditions.$t)) for t in tracers]
+
+    if isnothing(p)
+        p = [getfield(model, f) for f in fieldnames(typeof(model))]
+    end
+
+    prob = ODEProblem(modelODE!, u0, tspan, p)
+
+    return prob
+end

--- a/src/bgc_to_ode.jl
+++ b/src/bgc_to_ode.jl
@@ -1,25 +1,39 @@
 using OrdinaryDiffEq
 
-using Oceananigans.Biogeochemistry: required_biogeochemical_tracers
+using Oceananigans.Biogeochemistry:
+    required_biogeochemical_tracers, required_biogeochemical_auxiliary_fields
 
-function bgc_to_ode(biogeochemistry, PAR_f, init_conditions, tspan, p=nothing)
+"""
+    bgc_to_ode(biogeochemistry, PAR_f, init_conditions, tspan, p=nothing)
+
+
+"""
+function bgc_to_ode(biogeochemistry, PAR_f, init_conditions, tspan, parameters=nothing)
+
+    # retrieve tracer order
     model = biogeochemistry()
     tracers = required_biogeochemical_tracers(model)
 
-    function modelODE!(du, u, p, t)
-        model = biogeochemistry(p...)
+    # if no parameters specified, get all of them
+    if isnothing(parameters)
+        parameters = fieldnames(biogeochemistry)
+    end
+    # retrive parameter values from model struct
+    p = [getfield(model, f) for f in fieldnames(biogeochemistry) if f ∈ parameters]
 
+    function modelODE!(du, u, p, t)
+        params = NamedTuple{parameters}(p)
+        model = biogeochemistry(; params...)
+
+        # TODO: what if there are additional auxiliary fields here?
         PAR = PAR_f(t)
         for (i, tracer) in enumerate(tracers)
             du[i] = model(Val(tracer), 0, 0, 0, t, u..., PAR)
         end
     end
 
+    # make sure the initial values are passed in the right order
     u0 = [eval(:($init_conditions.$t)) for t in tracers]
-
-    if isnothing(p)
-        p = [getfield(model, f) for f in fieldnames(typeof(model))]
-    end
 
     prob = ODEProblem(modelODE!, u0, tspan, p)
 

--- a/src/bgc_to_ode.jl
+++ b/src/bgc_to_ode.jl
@@ -25,7 +25,7 @@ function bgc_to_ode(biogeochemistry, PAR_f, init_conditions, tspan, parameters=n
 
     # if no parameters specified, get all of them (except `sinking_velocities`)
     if isnothing(parameters)
-        parameters = filter(p -> p ∉ (:sinking_velocities,), fieldnames(biogeochemistry))
+        parameters = filter(f -> f ∉ (:sinking_velocities,), fieldnames(biogeochemistry))
     end
     # retrieve parameter values from model struct
     p = [getfield(model, f) for f in fieldnames(biogeochemistry) if f ∈ parameters]

--- a/src/bgc_to_ode.jl
+++ b/src/bgc_to_ode.jl
@@ -4,9 +4,18 @@ using Oceananigans.Biogeochemistry:
     required_biogeochemical_tracers, required_biogeochemical_auxiliary_fields
 
 """
-    bgc_to_ode(biogeochemistry, PAR_f, init_conditions, tspan, p=nothing)
+    bgc_to_ode(biogeochemistry, PAR_f, init_conditions, tspan, parameters=nothing) -> ODEProblem
 
+Generate ODEProblem from Biogeochemistry.
 
+# Arguments
+- `biogeochemistry`: subtype of Oceananigans.Biogeochemistry
+- `PAR_f`: a time dependant PAR function
+- `init_conditions`: a NamedTuple of initial tracer values
+- `tspan`: a Tuple of Floats indicating simulation start and stop times
+- `parameters`: ordered names of parameters that will be pasesed to ODEProblem, specified as
+   a Tuple of Symbols. Defaults to `nothing`, in which case all `biogeochemistry` parameters
+   are used.
 """
 function bgc_to_ode(biogeochemistry, PAR_f, init_conditions, tspan, parameters=nothing)
 
@@ -15,6 +24,7 @@ function bgc_to_ode(biogeochemistry, PAR_f, init_conditions, tspan, parameters=n
     tracers = required_biogeochemical_tracers(model)
 
     # if no parameters specified, get all of them
+    # Q: what if sinking velocities are included here ?!
     if isnothing(parameters)
         parameters = fieldnames(biogeochemistry)
     end
@@ -25,7 +35,7 @@ function bgc_to_ode(biogeochemistry, PAR_f, init_conditions, tspan, parameters=n
         params = NamedTuple{parameters}(p)
         model = biogeochemistry(; params...)
 
-        # TODO: what if there are additional auxiliary fields here?
+        # NOTE: in the future could have additional auxiliary fields here
         PAR = PAR_f(t)
         for (i, tracer) in enumerate(tracers)
             du[i] = model(Val(tracer), 0, 0, 0, t, u..., PAR)

--- a/src/bgc_to_ode.jl
+++ b/src/bgc_to_ode.jl
@@ -1,4 +1,4 @@
-using DifferentialEquations
+using OrdinaryDiffEq
 
 using Oceananigans.Biogeochemistry: required_biogeochemical_tracers
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,3 +4,4 @@ using Test
 include("test_dynamic.jl")
 include("test_box_model.jl")
 include("test_n2p2zd.jl")
+include("test_bgc_to_ode.jl")

--- a/test/test_bgc_to_ode.jl
+++ b/test/test_bgc_to_ode.jl
@@ -1,0 +1,31 @@
+using Agate
+using Agate.Library.Light
+
+using OrdinaryDiffEq
+
+using Oceananigans.Units
+
+@testset "bgc_to_ode" begin
+    include(joinpath("..", "examples", "NPZD", "tracers.jl"))
+
+    init_conditions = (Z=0.05, P=0.01, N=7.0, D=0.0)
+    tspan = (0.0, 365day)
+    Δt = dt = 7days
+
+    # uses all BGC params by default
+    prob = bgc_to_ode(NPZD, cyclical_PAR(; z=-10), init_conditions, tspan)
+    @test length(prob.p) == 11
+
+    # can also specify only some BGC parameters - this is useful for inference
+    params = (:μ₀, :kₙ, :lᵖᵈ, :α)
+    prob2 = bgc_to_ode(NPZD, cyclical_PAR(; z=-10), init_conditions, tspan, params)
+    @test length(prob2.p) == 4
+
+    # sanity check solution is correct if only passing some of the BGC parameters
+    sol_default = solve(prob, Tsit5(); saveat=Δt)
+    # NOTE: using default values in this example as well
+    p = [0.6989 / day, 2.3868, 0.0101 / day, 0.1953 / day]
+    sol_params = solve(prob2, Tsit5(); p=p, saveat=Δt)
+
+    @test sol_default == sol_params
+end


### PR DESCRIPTION
This PR adds a `bgc_to_ode` wrapper function which can be used to turn a BGC model into an ODEProblem object. The differential equations and inference examples have been simplified accordingly. I have run both examples to check the outputs remain the same and I have also added a small unit test. 

NOTES: there were issues with compiling a dependancy of DifferentialEquations.jl ([BoundaryValueDiffEq.jl](https://github.com/SciML/BoundaryValueDiffEq.jl)) and in the process of debugging that it occurred to me that as long as we aim to only solve ODEs we should use the more lightweight package OrdinaryDiffEq.jl (which also does not have this dependancy). So I updated our dependencies accordingly.