### PR TITLE
Import functions from library in example

### DIFF
--- a/examples/N2P2ZD/functions.jl
+++ b/examples/N2P2ZD/functions.jl
@@ -1,3 +1,7 @@
+using Agate.Library.Mortality
+using Agate.Library.Nutrients
+using Agate.Library.Photosynthesis
+
 function remineralization(D::Real, detritus_remineralization::Real)
     return D * detritus_remineralization
 end


### PR DESCRIPTION
This is not necessary to make the example run in Agate but is better practice for the `functions.jl` as a stand alone file.