### PR TITLE
Update high level constructor

### DIFF
--- a/examples/Photosynthesis/box_model.jl
+++ b/examples/Photosynthesis/box_model.jl
@@ -28,9 +28,12 @@ set!(full_model_default_photosynthesis; P1=0.01, P2=0.01, Z1=0.05, Z2=0.05, N=7.
 
 # Geider photosynthesis model
 N2P2ZD_geider_photosynthesis = construct_size_structured_NPZD(;
+    phyto_diameters = Dict(
+        "min_diameter" => 2,
+        "max_diameter" => 10,
+        "splitting" => "log_splitting",
+    ),
     phyto_args=Dict(
-        "diameters" =>
-            Dict("min_diameter" => 2, "max_diameter" => 10, "splitting" => "log_splitting"),
         "allometry" => Dict(
             "maximum_growth_rate" => Dict("a" => 2 / day, "b" => -0.15),
             "nutrient_half_saturation" => Dict("a" => 0.17, "b" => 0.27),

--- a/examples/Photosynthesis/box_model.jl
+++ b/examples/Photosynthesis/box_model.jl
@@ -5,7 +5,7 @@ using OceanBioME: Biogeochemistry
 using Oceananigans
 using Oceananigans.Units
 using Plots
-using Agate.Models.Constructors
+using Agate.Constructors
 using Agate.Models.Tracers
 using Agate.Library.Photosynthesis
 
@@ -28,10 +28,8 @@ set!(full_model_default_photosynthesis; P1=0.01, P2=0.01, Z1=0.05, Z2=0.05, N=7.
 
 # Geider photosynthesis model
 N2P2ZD_geider_photosynthesis = construct_size_structured_NPZD(;
-    phyto_diameters = Dict(
-        "min_diameter" => 2,
-        "max_diameter" => 10,
-        "splitting" => "log_splitting",
+    phyto_diameters=Dict(
+        "min_diameter" => 2, "max_diameter" => 10, "splitting" => "log_splitting"
     ),
     phyto_args=Dict(
         "allometry" => Dict(

--- a/examples/Photosynthesis/box_model.jl
+++ b/examples/Photosynthesis/box_model.jl
@@ -28,9 +28,6 @@ set!(full_model_default_photosynthesis; P1=0.01, P2=0.01, Z1=0.05, Z2=0.05, N=7.
 
 # Geider photosynthesis model
 N2P2ZD_geider_photosynthesis = construct_size_structured_NPZD(;
-    phyto_diameters=Dict(
-        "min_diameter" => 2, "max_diameter" => 10, "splitting" => "log_splitting"
-    ),
     phyto_args=Dict(
         "allometry" => Dict(
             "maximum_growth_rate" => Dict("a" => 2 / day, "b" => -0.15),

--- a/src/Agate.jl
+++ b/src/Agate.jl
@@ -2,9 +2,11 @@ module Agate
 
 include("Library/Library.jl")
 include("Models/Models.jl")
+include("Constructors/Constructors.jl")
 
 using .Library
 using .Models
+using .Constructors
 
 export compute_allometric_parameters
 export define_tracer_functions

--- a/src/Constructors/Constructors.jl
+++ b/src/Constructors/Constructors.jl
@@ -1,0 +1,13 @@
+"""
+Module for high level model constructors.
+"""
+
+module Constructors
+
+include("NPZD_size_structured.jl")
+
+using .NPZD_size_structured
+
+export construct_size_structured_NPZD
+
+end # module

--- a/src/Constructors/NPZD_size_structured.jl
+++ b/src/Constructors/NPZD_size_structured.jl
@@ -1,12 +1,12 @@
-module Constructors
+"""
+Module to construct an instance of an size-structured NPZD model.
+"""
 
-include("Biogeochemistry.jl")
-include("Parameters.jl")
-include("Tracers.jl")
+module NPZD_size_structured
 
-using .Biogeochemistry
-using .Parameters
-using .Tracers
+using Agate.Models.Biogeochemistry
+using Agate.Models.Parameters
+using Agate.Models.Tracers
 
 using Oceananigans.Units
 

--- a/src/Constructors/NPZD_size_structured.jl
+++ b/src/Constructors/NPZD_size_structured.jl
@@ -99,10 +99,10 @@ need to be specified.
 function construct_size_structured_NPZD(;
     n_phyto=2,
     n_zoo=2,
-    phyto_diameters = Dict(
+    phyto_diameters=Dict(
         "min_diameter" => 2, "max_diameter" => 10, "splitting" => "log_splitting"
     ),
-    zoo_diameters = Dict(
+    zoo_diameters=Dict(
         "min_diameter" => 20, "max_diameter" => 100, "splitting" => "linear_splitting"
     ),
     nutrient_dynamics=nutrients_typical,
@@ -117,9 +117,9 @@ function construct_size_structured_NPZD(;
     assimilation_efficiency_matrix=nothing,
 )
     phyto_args["n"] = n_phyto
-    phyto_args["diameters"] =  phyto_diameters
+    phyto_args["diameters"] = phyto_diameters
     zoo_args["n"] = n_zoo
-    zoo_args["diameters"] =  zoo_diameters
+    zoo_args["diameters"] = zoo_diameters
 
     # compute emergent parameters
     defined_parameters = Dict("P" => phyto_args, "Z" => zoo_args)

--- a/src/Models/Constructors.jl
+++ b/src/Models/Constructors.jl
@@ -12,6 +12,50 @@ using Oceananigans.Units
 
 export construct_size_structured_NPZD
 
+DEFAULT_PHYTO_ARGS = Dict(
+    "diameters" =>
+        Dict("min_diameter" => 2, "max_diameter" => 10, "splitting" => "log_splitting"),
+    "allometry" => Dict(
+        "maximum_growth_rate" => Dict("a" => 2 / day, "b" => -0.15),
+        "nutrient_half_saturation" => Dict("a" => 0.17, "b" => 0.27),
+    ),
+    "linear_mortality" => 8e-7 / second,
+    "alpha" => 0.1953 / day,
+)
+
+DEFAULT_ZOO_ARGS = Dict(
+    "diameters" => Dict(
+        "min_diameter" => 20, "max_diameter" => 100, "splitting" => "linear_splitting"
+    ),
+    "allometry" => Dict("maximum_predation_rate" => Dict("a" => 30.84 / day, "b" => -0.16)),
+    "linear_mortality" => 8e-7 / second,
+    "holling_half_saturation" => 5.0,
+    "quadratic_mortality" => 1e-6 / second,
+)
+
+DEFAULT_INTERACTION_ARGS = Dict(
+    "P" => Dict(
+        "can_eat" => 0,
+        "can_be_eaten" => 1,
+        "optimum_predator_prey_ratio" => 0,
+        "protection" => 0,
+        "specificity" => 0,
+        "assimilation_efficiency" => 0,
+    ),
+    "Z" => Dict(
+        "can_eat" => 1,
+        "can_be_eaten" => 0,
+        "optimum_predator_prey_ratio" => 10,
+        "protection" => 1,
+        "specificity" => 0.3,
+        "assimilation_efficiency" => 0.32,
+    ),
+)
+
+DEFAULT_BGC_ARGS = Dict(
+    "detritus_remineralization" => 0.1213 / day, "mortality_export_fraction" => 0.5
+)
+
 """
 Construct an instance of an size-structured NPZD model.
 
@@ -37,11 +81,15 @@ need to be specified.
 - `detritus_dynamics`: expression describing how detritus evolves over time
 - `phyto_dynamics`: expression describing how phytoplankton grow
 - `zoo_dynamics`: expression describing how zooplankton grow
-- `phyto_args`: Dictionary of phytoplankton parameters
-- `zoo_args`: Dictionary of zooplankton parameters
+- `phyto_args`: Dictionary of phytoplankton parameters, for default values see:
+    `Agate.Models.Constructors.DEFAULT_PHYTO_ARGS`
+- `zoo_args`: Dictionary of zooplankton parameters, for default values see:
+    `Agate.Models.Constructors.DEFAULT_ZOO_ARGS`
 - `interaction_args`: Dictionary of arguments from which a palatability and assimilation
-   efficiency matrix between all plankton can be computed
-- `bgc_args`: biogeochemistry parameters related to nutrient and detritus
+   efficiency matrix between all plankton can be computed, for default values  see:
+    `Agate.Models.Constructors.DEFAULT_INTERACTION_ARGS`
+- `bgc_args`: biogeochemistry parameters related to nutrient and detritus, for default
+    values see: `Agate.Models.Constructors.DEFAULT_BGC_ARGS`
 - `palatability_matrix`: optional palatability matrix passed as a NamedArray, if provided
    then `paralatability_args` are ignored
 - `assimilation_efficiency_matrix`: optional assimilation efficiency matrix passed as a
@@ -54,49 +102,10 @@ function construct_size_structured_NPZD(;
     detritus_dynamics=detritus_typical,
     phyto_dynamics=phytoplankton_growth_single_nutrient,
     zoo_dynamics=zooplankton_growth_simplified,
-    phyto_args=Dict(
-        "diameters" =>
-            Dict("min_diameter" => 2, "max_diameter" => 10, "splitting" => "log_splitting"),
-        "allometry" => Dict(
-            "maximum_growth_rate" => Dict("a" => 2 / day, "b" => -0.15),
-            "nutrient_half_saturation" => Dict("a" => 0.17, "b" => 0.27),
-        ),
-        "linear_mortality" => 8e-7 / second,
-        "alpha" => 0.1953 / day,
-    ),
-    zoo_args=Dict(
-        "diameters" => Dict(
-            "min_diameter" => 20,
-            "max_diameter" => 100,
-            "splitting" => "linear_splitting",
-        ),
-        "allometry" =>
-            Dict("maximum_predation_rate" => Dict("a" => 30.84 / day, "b" => -0.16)),
-        "linear_mortality" => 8e-7 / second,
-        "holling_half_saturation" => 5.0,
-        "quadratic_mortality" => 1e-6 / second,
-    ),
-    interaction_args=Dict(
-        "P" => Dict(
-            "can_eat" => 0,
-            "can_be_eaten" => 1,
-            "optimum_predator_prey_ratio" => 0,
-            "protection" => 0,
-            "specificity" => 0,
-            "assimilation_efficiency" => 0,
-        ),
-        "Z" => Dict(
-            "can_eat" => 1,
-            "can_be_eaten" => 0,
-            "optimum_predator_prey_ratio" => 10,
-            "protection" => 1,
-            "specificity" => 0.3,
-            "assimilation_efficiency" => 0.32,
-        ),
-    ),
-    bgc_args=Dict(
-        "detritus_remineralization" => 0.1213 / day, "mortality_export_fraction" => 0.5
-    ),
+    phyto_args=DEFAULT_PHYTO_ARGS,
+    zoo_args=DEFAULT_ZOO_ARGS,
+    interaction_args=DEFAULT_INTERACTION_ARGS,
+    bgc_args=DEFAULT_BGC_ARGS,
     palatability_matrix=nothing,
     assimilation_efficiency_matrix=nothing,
 )

--- a/src/Models/Models.jl
+++ b/src/Models/Models.jl
@@ -1,17 +1,14 @@
 module Models
 
 include("Biogeochemistry.jl")
-include("Constructors.jl")
 include("Parameters.jl")
 include("Tracers.jl")
 
 using .Biogeochemistry
-using .Constructors
 using .Parameters
 using .Tracers
 
 export compute_allometric_parameters
 export define_tracer_functions
-export construct_size_structured_NPZD
 
 end # module

--- a/src/Models/Parameters.jl
+++ b/src/Models/Parameters.jl
@@ -98,14 +98,19 @@ function compute_allometric_parameters(plankton::Dict)
         # 1. compute diameters (unless already specified)
         if isa(params["diameters"], Dict)
             # get the appropriate splitting function from the Parameters module
-            splitting_function = getfield(Parameters, Symbol(params["diameters"]["splitting"]))
+            splitting_function = getfield(
+                Parameters, Symbol(params["diameters"]["splitting"])
+            )
             diameters = splitting_function(
                 params["diameters"]["min_diameter"], params["diameters"]["max_diameter"], n
             )
         else
+            if length(params["diameters"]) != n
+                throw(ArgumentError("diameters array must have length $(n)"))
+            end
             diameters = params["diameters"]
         end
-            results["diameters"] = vcat(
+        results["diameters"] = vcat(
             results["diameters"], NamedArray(diameters, plankton_names)
         )
 

--- a/src/Models/Parameters.jl
+++ b/src/Models/Parameters.jl
@@ -97,12 +97,17 @@ function compute_allometric_parameters(plankton::Dict)
         n = params["n"]
         plankton_names = ["$plankton_name$i" for i in 1:n]
 
-        # 1. compute diameters
-        splitting_function = getfield(Parameters, Symbol(params["diameters"]["splitting"]))
-        diameters = splitting_function(
-            params["diameters"]["min_diameter"], params["diameters"]["max_diameter"], n
-        )
-        results["diameters"] = vcat(
+        # 1. compute diameters (unless already specified)
+        if isa(params["diameters"], Dict)
+            # get the appropriate splitting function from the Parameters module
+            splitting_function = getfield(Parameters, Symbol(params["diameters"]["splitting"]))
+            diameters = splitting_function(
+                params["diameters"]["min_diameter"], params["diameters"]["max_diameter"], n
+            )
+        else
+            diameters = params["diameters"]
+        end
+            results["diameters"] = vcat(
             results["diameters"], NamedArray(diameters, plankton_names)
         )
 

--- a/src/Models/Parameters.jl
+++ b/src/Models/Parameters.jl
@@ -3,10 +3,8 @@ module Parameters
 using DataStructures: DefaultDict
 using NamedArrays
 
-include(joinpath("..", "Library", "Library.jl"))
-
-using .Library.Allometry
-using .Library.Predation
+using Agate.Library.Allometry
+using Agate.Library.Predation
 
 export compute_allometric_parameters
 

--- a/src/Models/Parameters.jl
+++ b/src/Models/Parameters.jl
@@ -33,7 +33,8 @@ using names generated in the first step.
        `Dict(<group name> => Dict(<parameter> => <value>, ....), ...)`
 
     The Dictionary for each group (e.g., "P", "Z" or "cocco") has to contain at least the
-    keys "n" and "diameters" and have the following form:
+    keys "n" and "diameters", which are either an array of values or a dictionary of the
+    following form:
         ```
         Dict(
             "P" => Dict(
@@ -61,8 +62,8 @@ using names generated in the first step.
             "P" => Dict(
                 ...,
                 "allometry" => Dict(
-                    "maximum_growth_rate" => Dict("a" => 1, "b" => 1),
-                    "nutrient_half_saturation" => Dict("a" => 1, "b" => 1),
+                    "maximum_growth_rate" => Dict("a" => 2.3148e-5, "b" => -0.15),
+                    "nutrient_half_saturation" => Dict("a" => 0.17, "b" => 0.27),
                 ),
                 ...
             ),

--- a/test/test_constructor.jl
+++ b/test/test_constructor.jl
@@ -82,12 +82,12 @@ using Agate.Models.Tracers
 
         # N2P2ZD model constructed with user-defined functions (geider growth)
         N2P2ZD_geider = construct_size_structured_NPZD(;
+            phyto_diameters = Dict(
+                "min_diameter" => 2,
+                "max_diameter" => 10,
+                "splitting" => "log_splitting",
+            ),
             phyto_args=Dict(
-                "diameters" => Dict(
-                    "min_diameter" => 2,
-                    "max_diameter" => 10,
-                    "splitting" => "log_splitting",
-                ),
                 "allometry" => Dict(
                     "maximum_growth_rate" => Dict("a" => 2 / day, "b" => -0.15),
                     "nutrient_half_saturation" => Dict("a" => 0.17, "b" => 0.27),

--- a/test/test_constructor.jl
+++ b/test/test_constructor.jl
@@ -3,6 +3,16 @@ using NamedArrays
 using Agate.Models.Tracers
 
 @testset "Models.Constructor" begin
+
+    # declare constants reused in all tests
+    P1 = 0.01
+    P2 = 0.01
+    Z1 = 0.05
+    Z2 = 0.05
+    N = 7.0
+    D = 1
+    PAR = 100
+
     @testset "N2P2ZD model" begin
         # N2P2ZD model defined using low level syntax
         include(joinpath("..", "examples", "N2P2ZD", "tracers.jl"))
@@ -11,14 +21,6 @@ using Agate.Models.Tracers
         # N2P2ZD model constructed from emergent parameters
         N2P2ZD_constructed = construct_size_structured_NPZD()
         model_constructed = N2P2ZD_constructed()
-
-        P1 = 0.01
-        P2 = 0.01
-        Z1 = 0.05
-        Z2 = 0.05
-        N = 7.0
-        D = 1
-        PAR = 100
 
         @test !iszero(model_constructed(Val(:N), 0, 0, 0, 0, P1, P2, Z1, Z2, N, D, PAR))
         @test !iszero(model_constructed(Val(:D), 0, 0, 0, 0, P1, P2, Z1, Z2, N, D, PAR))
@@ -78,6 +80,23 @@ using Agate.Models.Tracers
         )
     end
 
+    @testset "Diameters passed as an array" begin
+
+        # diameters can be passed as an array of values rather than a dictionary
+        # this is useful in the case where we want 1 phytoplankton with a given diameter
+        # it could also be used to fix the diameters of multiple phytoplankton in the model
+        NP2ZD = construct_size_structured_NPZD(n_phyto=1, phyto_diameters=[2])
+        model = NP2ZD()
+
+        # only 1 phyto, 2 zoo tracers (unlike other tests here)
+        @test !iszero(model(Val(:N), 0, 0, 0, 0, P1, Z1, Z2, N, D, PAR))
+        @test !iszero(model(Val(:D), 0, 0, 0, 0, P1, Z1, Z2, N, D, PAR))
+        @test !iszero(model(Val(:P1), 0, 0, 0, 0, P1, Z1, Z2, N, D, PAR))
+        @test !iszero(model(Val(:Z1), 0, 0, 0, 0, P1, Z1, Z2, N, D, PAR))
+        @test !iszero(model(Val(:Z2), 0, 0, 0, 0, P1, Z1, Z2, N, D, PAR))
+
+    end
+
     @testset "Alternative instantiation" begin
 
         # N2P2ZD model constructed with user-defined functions (geider growth)
@@ -101,14 +120,6 @@ using Agate.Models.Tracers
         )
 
         model_geider = N2P2ZD_geider()
-
-        P1 = 0.01
-        P2 = 0.01
-        Z1 = 0.05
-        Z2 = 0.05
-        N = 7.0
-        D = 1
-        PAR = 100
 
         @test !iszero(model_geider(Val(:N), 0, 0, 0, 0, P1, P2, Z1, Z2, N, D, PAR))
         @test !iszero(model_geider(Val(:D), 0, 0, 0, 0, P1, P2, Z1, Z2, N, D, PAR))

--- a/test/test_constructor.jl
+++ b/test/test_constructor.jl
@@ -85,7 +85,7 @@ using Agate.Models.Tracers
         # diameters can be passed as an array of values rather than a dictionary
         # this is useful in the case where we want 1 phytoplankton with a given diameter
         # it could also be used to fix the diameters of multiple phytoplankton in the model
-        NP2ZD = construct_size_structured_NPZD(n_phyto=1, phyto_diameters=[2])
+        NP2ZD = construct_size_structured_NPZD(; n_phyto=1, phyto_diameters=[2])
         model = NP2ZD()
 
         # only 1 phyto, 2 zoo tracers (unlike other tests here)
@@ -95,16 +95,18 @@ using Agate.Models.Tracers
         @test !iszero(model(Val(:Z1), 0, 0, 0, 0, P1, Z1, Z2, N, D, PAR))
         @test !iszero(model(Val(:Z2), 0, 0, 0, 0, P1, Z1, Z2, N, D, PAR))
 
+        # by default have 2 phyto so expect 2 diameters
+        @test_throws ArgumentError construct_size_structured_NPZD(;
+            phyto_diameters=[1, 2, 3]
+        )
     end
 
     @testset "Alternative instantiation" begin
 
         # N2P2ZD model constructed with user-defined functions (geider growth)
         N2P2ZD_geider = construct_size_structured_NPZD(;
-            phyto_diameters = Dict(
-                "min_diameter" => 2,
-                "max_diameter" => 10,
-                "splitting" => "log_splitting",
+            phyto_diameters=Dict(
+                "min_diameter" => 2, "max_diameter" => 10, "splitting" => "log_splitting"
             ),
             phyto_args=Dict(
                 "allometry" => Dict(


### PR DESCRIPTION
Closes #106 

This PR separates the diameter arguments from the other plankton specific arguments into a separate dictionary. The code is also refactored such that diameters can now be specified as a dictionary which is used to compute an array of values or they can be passed as an array of values by the user. This means that in the case of the user wanting to have a single plankton of diameter 2, the user can just do the following:

```
NP2ZD = construct_size_structured_NPZD(n_phyto=1, phyto_diameters=[2])
```

This is illustrated in tests.

I also declared all dictionaries of default arguments in the global namespace so that the user can access them. This makes updating a single value easy for the user. For example:

```
my_new_args = Agate.Models.Constructors.DEFAULT_PHYTO_ARGS
my_new_args["alpha"] = 0.3953 / day
model_constructed = construct_size_structured_NPZD(
    phyto_args=my_new_args
)
```