### PR TITLE
Refactor tracers

### DIFF
--- a/src/Constructors/NPZD_size_structured.jl
+++ b/src/Constructors/NPZD_size_structured.jl
@@ -8,6 +8,7 @@ using Agate.Models.Biogeochemistry
 using Agate.Models.Parameters
 using Agate.Models.Tracers
 
+using NamedArrays
 using Oceananigans.Units
 
 export construct_size_structured_NPZD
@@ -42,7 +43,7 @@ DEFAULT_INTERACTION_ARGS = Dict(
 DEFAULT_CONSTANT_ARGS_SINGLE_NUTRIENT = Dict(
     "detritus_remineralization" => 0.1213 / day,
     "mortality_export_fraction" => 0.5,
-    "linear_mortality" => 8e-7 / second,
+    "linear_mortality" => NamedArray([8e-7 / second, 8e-7 / second], ["P", "Z"]),
     "holling_half_saturation" => 5.0,
     "quadratic_mortality" => 1e-6 / second,
     "alpha" => 0.1953 / day,
@@ -51,7 +52,7 @@ DEFAULT_CONSTANT_ARGS_SINGLE_NUTRIENT = Dict(
 DEFAULT_CONSTANT_ARGS_GEIDER = Dict(
     "detritus_remineralization" => 0.1213 / day,
     "mortality_export_fraction" => 0.5,
-    "linear_mortality" => 8e-7 / second,
+    "linear_mortality" => NamedArray([8e-7 / second, 8e-7 / second], ["P", "Z"]),
     "holling_half_saturation" => 5.0,
     "quadratic_mortality" => 1e-6 / second,
     "photosynthetic_slope" => 0.46e-5,
@@ -98,9 +99,9 @@ need to be specified.
     dependant plankton parameters as well as biogeochemistry parameters related to nutrient
     and detritus, for default values see `Agate.Models.Constructors.DEFAULT_CONSTANT_ARGS`
 - `palatability_matrix`: optional palatability matrix passed as a NamedArray, if provided
-   then `interaction_args` are not used to compute this
+    then `interaction_args` are not used to compute this
 - `assimilation_efficiency_matrix`: optional assimilation efficiency matrix passed as a
-   NamedArray, if provided then `interaction_args` are not used to compute this
+    NamedArray, if provided then `interaction_args` are not used to compute this
 """
 function construct_size_structured_NPZD(;
     n_phyto=2,

--- a/src/Library/mortality.jl
+++ b/src/Library/mortality.jl
@@ -29,11 +29,14 @@ Net loss of all plankton due to linear mortality.
 
 # Arguments
 - `P`: NamedArray which includes all plankton concentration values
-- `linear_mortality`: plankton linear mortality rate
+- `linear_mortality`: NamedArray of plankton linear mortality rates
 """
 function net_linear_loss(P, linear_mortality, fraction)
-    # sum over all plankton in `P`
-    return sum([linear_loss(P[name], linear_mortality) for name in names(P, 1)]) * fraction
+    # sum over all plankton in `P` - strip digits from plankton name to get its type (e.g., "P")
+    return sum([
+        linear_loss(P[name], linear_mortality[replace(name, r"\d+" => "")]) for
+        name in names(P, 1)
+    ]) * fraction
 end
 
 """

--- a/src/Library/mortality.jl
+++ b/src/Library/mortality.jl
@@ -32,7 +32,7 @@ Net loss of all plankton due to linear mortality.
 - `linear_mortality`: NamedArray of plankton linear mortality rates
 """
 function net_linear_loss(P, linear_mortality, fraction)
-    # sum over all plankton in `P` - strip digits from plankton name to get its type (e.g., "P")
+    # sum over all plankton in `P` - strip digits from plankton name to get its type (e.g., "Z")
     return sum([
         linear_loss(P[name], linear_mortality[replace(name, r"\d+" => "")]) for
         name in names(P, 1)

--- a/src/Models/Tracers.jl
+++ b/src/Models/Tracers.jl
@@ -124,6 +124,8 @@ for overview. All arguments in the functions are either a NamedArray or a Float.
 """
 function phytoplankton_growth_single_nutrient(plankton_array, plankton_name)
     plankton_symbol = Symbol(plankton_name)
+    # remove any digits to get just the type identifier
+    plankton_type = replace(plankton_name, r"\d+" => "")
     return :(
         photosynthetic_growth_single_nutrient(
             N,
@@ -139,7 +141,7 @@ function phytoplankton_growth_single_nutrient(plankton_array, plankton_name)
             holling_half_saturation,
             palatability_matrix,
         ) - linear_loss(
-            $(plankton_symbol), linear_mortality[$(replace(plankton_name, r"\d+" => ""))]
+            $(plankton_symbol), linear_mortality[$plankton_type]
         )
     )
 end
@@ -158,6 +160,8 @@ for overview. All arguments in the functions are either a NamedArray or a Float.
 """
 function phytoplankton_growth_single_nutrient_geider_light(plankton_array, plankton_name)
     plankton_symbol = Symbol(plankton_name)
+    # remove any digits to get just the type identifier
+    plankton_type = replace(plankton_name, r"\d+" => "")
     return :(
         photosynthetic_growth_single_nutrient_geider_light(
             N,
@@ -174,7 +178,7 @@ function phytoplankton_growth_single_nutrient_geider_light(plankton_array, plank
             holling_half_saturation,
             palatability_matrix,
         ) - linear_loss(
-            $(plankton_symbol), linear_mortality[$(replace(plankton_name, r"\d+" => ""))]
+            $(plankton_symbol), linear_mortality[$plankton_type]
         )
     )
 end
@@ -193,6 +197,8 @@ for overview. All arguments in the functions are either a NamedArray or a Float.
 """
 function zooplankton_growth_simplified(plankton_array, plankton_name)
     plankton_symbol = Symbol(plankton_name)
+    # remove any digits to get just the type identifier
+    plankton_type = replace(plankton_name, r"\d+" => "")
     return :(
         summed_predation_gain_preferential(
             $plankton_name,
@@ -202,7 +208,7 @@ function zooplankton_growth_simplified(plankton_array, plankton_name)
             holling_half_saturation,
             palatability_matrix,
         ) - linear_loss(
-            $(plankton_symbol), linear_mortality[$(replace(plankton_name, r"\d+" => ""))]
+            $(plankton_symbol), linear_mortality[$plankton_type]
         ) - quadratic_loss($(plankton_symbol), quadratic_mortality)
     )
 end

--- a/src/Models/Tracers.jl
+++ b/src/Models/Tracers.jl
@@ -138,7 +138,9 @@ function phytoplankton_growth_single_nutrient(plankton_array, plankton_name)
             maximum_predation_rate,
             holling_half_saturation,
             palatability_matrix,
-        ) - linear_loss($(plankton_symbol), linear_mortality)
+        ) - linear_loss(
+            $(plankton_symbol), linear_mortality[$(replace(plankton_name, r"\d+" => ""))]
+        )
     )
 end
 
@@ -171,7 +173,9 @@ function phytoplankton_growth_single_nutrient_geider_light(plankton_array, plank
             maximum_predation_rate,
             holling_half_saturation,
             palatability_matrix,
-        ) - linear_loss($(plankton_symbol), linear_mortality)
+        ) - linear_loss(
+            $(plankton_symbol), linear_mortality[$(replace(plankton_name, r"\d+" => ""))]
+        )
     )
 end
 
@@ -197,8 +201,9 @@ function zooplankton_growth_simplified(plankton_array, plankton_name)
             maximum_predation_rate,
             holling_half_saturation,
             palatability_matrix,
-        ) - linear_loss($(plankton_symbol), linear_mortality) -
-        quadratic_loss($(plankton_symbol), quadratic_mortality)
+        ) - linear_loss(
+            $(plankton_symbol), linear_mortality[$(replace(plankton_name, r"\d+" => ""))]
+        ) - quadratic_loss($(plankton_symbol), quadratic_mortality)
     )
 end
 

--- a/src/Models/Tracers.jl
+++ b/src/Models/Tracers.jl
@@ -140,9 +140,7 @@ function phytoplankton_growth_single_nutrient(plankton_array, plankton_name)
             maximum_predation_rate,
             holling_half_saturation,
             palatability_matrix,
-        ) - linear_loss(
-            $(plankton_symbol), linear_mortality[$plankton_type]
-        )
+        ) - linear_loss($(plankton_symbol), linear_mortality[$plankton_type])
     )
 end
 
@@ -177,9 +175,7 @@ function phytoplankton_growth_single_nutrient_geider_light(plankton_array, plank
             maximum_predation_rate,
             holling_half_saturation,
             palatability_matrix,
-        ) - linear_loss(
-            $(plankton_symbol), linear_mortality[$plankton_type]
-        )
+        ) - linear_loss($(plankton_symbol), linear_mortality[$plankton_type])
     )
 end
 
@@ -207,9 +203,8 @@ function zooplankton_growth_simplified(plankton_array, plankton_name)
             maximum_predation_rate,
             holling_half_saturation,
             palatability_matrix,
-        ) - linear_loss(
-            $(plankton_symbol), linear_mortality[$plankton_type]
-        ) - quadratic_loss($(plankton_symbol), quadratic_mortality)
+        ) - linear_loss($(plankton_symbol), linear_mortality[$plankton_type]) -
+        quadratic_loss($(plankton_symbol), quadratic_mortality)
     )
 end
 


### PR DESCRIPTION
Refactoring tracer expressions so that any parameters that are constants (i.e., the same for all plankton irrespective of size) are not unnecessarily treated as arrays. I also updated the arguments that are used as input to the constructor to now separate arguments into:
- those used to compute emergent parameters
- those used to compute palatability/assimilation efficiency
- everything else (i.e., constants)

I also updated the sum/net functions to make it explicit what types of plankton we are summing over (in the cases where it's not all of them). The update was written so that one could pass the functions a list of, say, predator types.

The refactor here is a first step in simplifying the constructor interface in #143 but I thought it's worth merging this as a separate PR to avoid that one getting too big for review.

TODO:
- [ ] handle type specific constant parameters (e.g., alpha can vary by plankton type but not size)