### PR TITLE
Update dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,23 +4,19 @@ version = "0.1.1"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
 OceanBioME = "a49af516-9db8-4be4-be45-1dad61c5a376"
 Oceananigans = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
-Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 DataStructures = "0.18.20"
-DifferentialEquations = "7.15.0"
-OceanBioME = "0.13.2"
-Oceananigans = "0.93.3"
+OceanBioME = "0.14.0"
+Oceananigans = "^0.95.20, 0.96"
 Plots = "1.40.10"
 StatsPlots = "0.15.7"
-Turing = "0.35.3"
-julia = "1.9"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -13,6 +13,7 @@ using Agate.Library.Remineralization
 
 using UUIDs
 
+using OceanBioME
 using Oceananigans.Biogeochemistry: AbstractContinuousFormBiogeochemistry
 using Oceananigans.Fields: ZeroField
 
@@ -20,7 +21,6 @@ import Oceananigans.Biogeochemistry:
     required_biogeochemical_tracers,
     required_biogeochemical_auxiliary_fields,
     biogeochemical_drift_velocity
-import OceanBioME.Models.Sediments: sinking_tracers
 
 export define_tracer_functions, expression_check, create_bgc_struct, add_bgc_methods!
 
@@ -43,7 +43,7 @@ Create an Oceananigans.Biogeochemistry model type.
 - `auxiliary_fields`: an iterable of auxiliary field variables, defaults to `[:PAR]`
 - `helper_functions`: optional path to a file of helper functions used in tracer expressions
 - `sinking_velocities`: optional NamedTuple of constant sinking, of fields (i.e. `ZFaceField(...)`)
-   for any tracers which sink returned by OceanBioME.Models.Sediments: sinking_tracers.
+   for any tracers which sink returned by OceanBioME.Sediments: sinking_tracers.
 
 !!! warning
 
@@ -101,7 +101,7 @@ Create a subtype of Oceananigans.Biogeochemistry with field names defined in `pa
 
 # Keywords
 - `sinking_velocities`: optional NamedTuple of constant sinking, of fields (i.e. `ZFaceField(...)`)
-   for any tracers which sink returned by OceanBioME.Models.Sediments: sinking_tracers.
+   for any tracers which sink returned by OceanBioME.Sediments: sinking_tracers.
 
 !!! warning
 
@@ -295,9 +295,6 @@ function add_bgc_methods!(
             end
         end
         eval(sink_velocity_method)
-
-        # this function is used in the OceanBioME sediment models
-        eval(:(sinking_tracers(bgc::$(bgc_type)) = keys(bgc.sinking_velocities)))
     end
 
     return bgc_type

--- a/test/test_biogeochemistry.jl
+++ b/test/test_biogeochemistry.jl
@@ -132,8 +132,6 @@ using Oceananigans.Biogeochemistry:
 
             model = NPZD_sink()
 
-            @test OceanBioME.Models.Sediments.sinking_tracers(model) == (:P, :D)
-
             @test biogeochemical_drift_velocity(model, Val(:P)).w.data[1, 1, 1] ==
                 -0.2551 / day
             @test biogeochemical_drift_velocity(model, Val(:D)).w.data[1, 1, 1] ==

--- a/test/test_constructor.jl
+++ b/test/test_constructor.jl
@@ -212,8 +212,6 @@ using Oceananigans.Biogeochemistry:
         )
         model = N2P2ZD_sink()
 
-        @test OceanBioME.Models.Sediments.sinking_tracers(model) == (:P1, :P2, :D)
-
         @test biogeochemical_drift_velocity(model, Val(:P1)).w.data[1, 1, 1] ==
             -0.2551 / day
         @test biogeochemical_drift_velocity(model, Val(:P2)).w.data[1, 1, 1] ==
@@ -230,6 +228,5 @@ using Oceananigans.Biogeochemistry:
             sinking_tracers=(P1=0.2551 / day, P2=0.2551 / day, D=2.7489 / day),
             grid=column_grid,
         )
-        @test OceanBioME.Models.Sediments.sinking_tracers(col_model) == (:P1, :P2, :D)
     end
 end


### PR DESCRIPTION
Closes #182 
Closes #103 

Also removes `sinking_tracers` function as it is no longer used in the latest version of OceanBioME sediment models (which we never actually tried to integrate with anyways).