### PR TITLE
Add compats to docs Project.toml

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -6,3 +6,8 @@ JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 OceanBioME = "a49af516-9db8-4be4-be45-1dad61c5a376"
 Oceananigans = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
+
+[compat]
+OceanBioME = "0.14.0"
+Oceananigans = "^0.95.20, 0.96"
+julia = "1.10"


### PR DESCRIPTION
Adds compats to 'docs/Project.toml'

Hopefully fixes a bug in the doc build "UndefVarError: `JLD2OutputWriter` not defined" as this function was renamed in a recent version of Oceananigans.jl to  `JLD2Writer` ...

