### PR TITLE
Fix AD parameter typing and optimize ode_problem

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Agate"
 uuid = "41889b7c-c35c-4f16-abd7-94b299d9fd29"
-version = "0.7.1"
+version = "0.7.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -32,8 +32,8 @@ if BUILD_COLUMN_EXAMPLE
 end
 
 differentiable_modelling = [
-    "Forward-mode AD sensitivity" => "forwarddiff_nipizd_ode",
-    "Parameter sensitivity with reverse-mode AD" => "ad_nipizd_parameter_sensitivity",
+    "Forward-mode AD sensitivity" => "forward_mode_ad_nipizd_sensitivity",
+    "Reverse-mode AD sensitivity" => "reverse_mode_ad_nipizd_sensitivity",
 ]
 
 

--- a/examples/forward_mode_ad_nipizd_sensitivity.jl
+++ b/examples/forward_mode_ad_nipizd_sensitivity.jl
@@ -1,4 +1,4 @@
-# # [Forward-mode AD sensitivity] (@id forwarddiff_nipizd_ode_example)
+# # [Forward-mode AD sensitivity] (@id forward_mode_ad_nipizd_sensitivity_example)
 
 # In this example we use ForwardDiff.jl to compute the sensitivity of phytoplankton 1 (P1) in an N2P2ZD model to P1's maximum growth rate parameter.
 
@@ -135,7 +135,7 @@ lines!(
 )
 axislegend(ax2; position=:rb)
 
-output_path = joinpath(@__DIR__, "forwarddiff_nipizd_ode_sensitivity.png")
+output_path = joinpath(@__DIR__, "forward_mode_ad_nipizd_sensitivity.png")
 save(output_path, fig)
 
 fig

--- a/examples/forwarddiff_nipizd_ode.jl
+++ b/examples/forwarddiff_nipizd_ode.jl
@@ -8,7 +8,7 @@
 
 using Agate
 using ForwardDiff
-using OrdinaryDiffEq: ODEProblem, Tsit5, solve
+using OrdinaryDiffEq: Tsit5, solve
 using CairoMakie
 using Printf
 
@@ -19,28 +19,22 @@ const NiPiZD = Agate.Models.NiPiZD
 const TRACERS = (:N, :D, :Z1, :Z2, :P1, :P2)
 nothing #hide
 
-# ## Constructing an ForwardDiff.jl compatible model
+# ## Static model and active parameter
 
-# Agate.jl uses an explicit constructor-boundary scalar type contract.
-# For ordinary Oceananigans.jl simulations this scalar type comes from the grid, or defaults to `Float64`.
-# For ForwardDiff.jl, we pass the active scalar type explicitly with `scalar_type = typeof(mu)`.
+# We construct the model once and let `Agate.Runtime.ode_problem` read P1's
+# maximum growth rate from the ODE parameter vector. During ForwardDiff.jl
+# calls only this active entry becomes a dual number; the stored model parameters
+# remain ordinary floating-point values.
 
-function nipizd_model_with_p1_growth_rate(mu)
-    T = typeof(mu)
+const BGC = NiPiZD.construct()
+const ACTIVE = Agate.Runtime.active_parameters(BGC; maximum_growth_rate=(:P1,))
 
-    return NiPiZD.construct(;
-        scalar_type=T,
-        parameters=(; maximum_growth_rate=(P1=mu, P2=T(0.7 / day))),
-    )
-end
-nothing #hide
-
-# Here `mu` is the maximum growth rate of `P1`.
-# The `P2` growth rate is held fixed, and omitted zooplankton entries are filled from defaults.
+# Here `theta[1]` is the maximum growth rate of `P1`. The `P2` growth rate and
+# omitted zooplankton entries are held fixed at the model defaults.
 
 # ## Standalone ODE problem
 
-# We define a small standalone ODE that calls Agate.jl's generated biological tendency functions directly.
+# We define a small standalone ODE through Agate.jl's SciML problem helper.
 
 function initial_conditions(::Type{T}) where {T}
     return T[7.0, 1.0, 0.05, 0.05, 0.01, 0.01]
@@ -48,23 +42,21 @@ end
 
 constant_PAR(::Type{T}) where {T} = T(100.0)
 
-function solve_nipizd(mu; saveat=range(0.0, 365day; length=366))
-    T = typeof(mu)
-    bgc = nipizd_model_with_p1_growth_rate(mu)
+function solve_nipizd(theta; saveat=range(0.0, 365day; length=366))
+    T = eltype(theta)
 
-    required_biogeochemical_tracers(bgc) == TRACERS ||
-        error("Unexpected NiPiZD tracer order: $(required_biogeochemical_tracers(bgc))")
+    required_biogeochemical_tracers(BGC) == TRACERS ||
+        error("Unexpected NiPiZD tracer order: $(required_biogeochemical_tracers(BGC))")
 
-    function rhs!(du, u, _, t)
-        PAR = constant_PAR(T)
-        for (i, tracer) in enumerate(TRACERS)
-            du[i] = bgc(Val(tracer), 0, 0, 0, t, u..., PAR)
-        end
-        return nothing
-    end
+    problem = Agate.Runtime.ode_problem(
+        BGC,
+        initial_conditions(T),
+        (first(saveat), last(saveat));
+        p=theta,
+        active_parameters=ACTIVE,
+        auxiliary=(; PAR=t -> constant_PAR(T)),
+    )
 
-    u0 = initial_conditions(T)
-    problem = ODEProblem(rhs!, u0, (first(saveat), last(saveat)))
     return solve(problem, Tsit5(); saveat=saveat, abstol=1e-10, reltol=1e-10)
 end
 nothing #hide
@@ -73,13 +65,13 @@ nothing #hide
 # This is the function that ForwardDiff.jl differentiates.
 
 function p1_trajectory(theta; saveat=range(0.0, 365day; length=366))
-    sol = solve_nipizd(theta[1]; saveat=saveat)
+    sol = solve_nipizd(theta; saveat=saveat)
     values = reduce(hcat, sol.u)
     return vec(values[5, :])
 end
 
 function p1_solution(mu; saveat=range(0.0, 365day; length=366))
-    sol = solve_nipizd(mu; saveat=saveat)
+    sol = solve_nipizd([mu]; saveat=saveat)
     values = reduce(hcat, sol.u)
     return vec(values[5, :])
 end

--- a/examples/reverse_mode_ad_nipizd_sensitivity.jl
+++ b/examples/reverse_mode_ad_nipizd_sensitivity.jl
@@ -187,7 +187,7 @@ function save_diagnostic_plots(reference_values, scaled_sensitivities, order)
     barplot!(ax, scaled_sensitivities[plot_order]; direction = :x)
     save(sensitivity_path, sensitivity_fig)
 
-    return trajectory_path, sensitivity_path
+    return (; trajectory = trajectory_fig, scaled_sensitivities = sensitivity_fig)
 end
 
 reference_values = solve_values(θ_REFERENCE)
@@ -197,4 +197,7 @@ scaled_sensitivities = abs.(θ_REFERENCE .* gradient)
 sensitivity_order = sortperm(scaled_sensitivities; rev = true)
 
 print_parameter_table(reference_objective, θ_REFERENCE, gradient, scaled_sensitivities, sensitivity_order)
-save_diagnostic_plots(reference_values, scaled_sensitivities, sensitivity_order)
+plots = save_diagnostic_plots(reference_values, scaled_sensitivities, sensitivity_order)
+
+plots.trajectory
+plots.scaled_sensitivities

--- a/examples/reverse_mode_ad_nipizd_sensitivity.jl
+++ b/examples/reverse_mode_ad_nipizd_sensitivity.jl
@@ -119,15 +119,18 @@ function solve_final_values(theta; sensealg = nothing)
     return values[:, end]
 end
 
-function final_total_phytoplankton(theta; sensealg = nothing)
-    final_values = solve_final_values(theta; sensealg)
-    total = zero(eltype(final_values))
+function total_phytoplankton(values)
+    total = zero(eltype(values))
 
     for i in PHYTOPLANKTON_INDICES
-        total += final_values[i]
+        total += values[i]
     end
 
     return total
+end
+
+function final_total_phytoplankton(theta; sensealg = nothing)
+    return total_phytoplankton(solve_final_values(theta; sensealg))
 end
 
 final_total_phytoplankton_adjoint(theta) = final_total_phytoplankton(theta; sensealg = SENSEALG)
@@ -163,12 +166,8 @@ function print_parameter_table(objective, theta, gradient, scaled_sensitivities,
     end
 end
 
-function save_diagnostic_plots(reference_values, scaled_sensitivities, order)
+function diagnostic_plots(reference_values, scaled_sensitivities, order)
     days = SAVEAT ./ day
-    output_directory = @__DIR__
-
-    trajectory_path = joinpath(output_directory, "reverse_mode_ad_nipizd_sensitivity_trajectory.png")
-    sensitivity_path = joinpath(output_directory, "reverse_mode_ad_nipizd_sensitivity_scaled_sensitivities.png")
 
     trajectory_fig = Figure()
     ax = Axis(trajectory_fig[1, 1],
@@ -176,7 +175,6 @@ function save_diagnostic_plots(reference_values, scaled_sensitivities, order)
               ylabel = "Total phytoplankton")
     phytoplankton = vec(sum(reference_values[PHYTOPLANKTON_INDICES, :]; dims = 1))
     lines!(ax, days, phytoplankton)
-    save(trajectory_path, trajectory_fig)
 
     plot_order = reverse(order)
 
@@ -185,19 +183,18 @@ function save_diagnostic_plots(reference_values, scaled_sensitivities, order)
               xlabel = "|θᵢ ∂J/∂θᵢ|",
               yticks = (1:length(plot_order), collect(PARAMETER_LABELS)[plot_order]))
     barplot!(ax, scaled_sensitivities[plot_order]; direction = :x)
-    save(sensitivity_path, sensitivity_fig)
 
     return (; trajectory = trajectory_fig, scaled_sensitivities = sensitivity_fig)
 end
 
 reference_values = solve_values(θ_REFERENCE)
-reference_objective = final_total_phytoplankton(θ_REFERENCE)
+reference_objective = total_phytoplankton(reference_values[:, end])
 gradient = enzyme_gradient(copy(θ_REFERENCE))
 scaled_sensitivities = abs.(θ_REFERENCE .* gradient)
 sensitivity_order = sortperm(scaled_sensitivities; rev = true)
 
 print_parameter_table(reference_objective, θ_REFERENCE, gradient, scaled_sensitivities, sensitivity_order)
-plots = save_diagnostic_plots(reference_values, scaled_sensitivities, sensitivity_order)
+plots = diagnostic_plots(reference_values, scaled_sensitivities, sensitivity_order)
 
 plots.trajectory
 plots.scaled_sensitivities

--- a/examples/reverse_mode_ad_nipizd_sensitivity.jl
+++ b/examples/reverse_mode_ad_nipizd_sensitivity.jl
@@ -1,4 +1,4 @@
-# # [Parameter sensitivity with reverse-mode AD] (@id ad_nipizd_parameter_sensitivity_example)
+# # [Reverse-mode AD sensitivity] (@id reverse_mode_ad_nipizd_sensitivity_example)
 
 # This example differentiates the final total phytoplankton biomass in the
 # default NiPiZD model with respect to several active parameters at once. The
@@ -167,8 +167,8 @@ function save_diagnostic_plots(reference_values, scaled_sensitivities, order)
     days = SAVEAT ./ day
     output_directory = @__DIR__
 
-    trajectory_path = joinpath(output_directory, "ad_nipizd_parameter_sensitivity_trajectory.png")
-    sensitivity_path = joinpath(output_directory, "ad_nipizd_parameter_sensitivity_scaled_sensitivities.png")
+    trajectory_path = joinpath(output_directory, "reverse_mode_ad_nipizd_sensitivity_trajectory.png")
+    sensitivity_path = joinpath(output_directory, "reverse_mode_ad_nipizd_sensitivity_scaled_sensitivities.png")
 
     trajectory_fig = Figure()
     ax = Axis(trajectory_fig[1, 1],

--- a/examples/reverse_mode_ad_nipizd_sensitivity.jl
+++ b/examples/reverse_mode_ad_nipizd_sensitivity.jl
@@ -11,9 +11,7 @@ using ADTypes: AutoEnzyme
 using CairoMakie
 import DifferentiationInterface
 using Enzyme
-using LinearAlgebra: norm
 using OrdinaryDiffEq: Tsit5, solve
-using Printf
 using SciMLBase: remake
 using SciMLSensitivity
 
@@ -135,6 +133,8 @@ end
 
 final_total_phytoplankton_adjoint(theta) = final_total_phytoplankton(theta; sensealg = SENSEALG)
 
+nothing #hide
+
 # ## Enzyme gradient through DifferentiationInterface
 
 # DifferentiationInterface provides a common gradient API for several Julia AD
@@ -142,29 +142,15 @@ final_total_phytoplankton_adjoint(theta) = final_total_phytoplankton(theta; sens
 # backend.
 #
 # Parameters can have different units and magnitudes, so raw gradients are not
-# always easy to compare. We rank sensitivities by `|θᵢ ∂J/∂θᵢ|`, which estimates
-# how much each parameter contributes relative to its reference value.
+# always easy to compare. We rank sensitivities visually by `|θᵢ ∂J/∂θᵢ|`,
+# which estimates how much each parameter contributes relative to its reference
+# value.
 
 const AD_BACKEND = AutoEnzyme(; mode = Enzyme.set_runtime_activity(Enzyme.Reverse))
 
 enzyme_gradient(theta) = DifferentiationInterface.gradient(final_total_phytoplankton_adjoint,
                                                            AD_BACKEND,
                                                            theta)
-
-function print_parameter_table(objective, theta, gradient, scaled_sensitivities, order)
-    total = sum(scaled_sensitivities)
-
-    @printf("Parameter sensitivity at θ_REFERENCE:\n")
-    @printf("  objective final(total phytoplankton): %.8e\n", objective)
-    @printf("  gradient norm:          %.8e\n", norm(gradient))
-    @printf("\n  %-34s %14s %14s %14s\n", "parameter", "θ", "∂J/∂θ", "|θ ∂J/∂θ|")
-
-    for n in order
-        share = iszero(total) ? 0.0 : 100 * scaled_sensitivities[n] / total
-        @printf("  %-34s %.8e % .8e %.8e  (%5.1f%%)\n",
-                PARAMETER_LABELS[n], theta[n], gradient[n], scaled_sensitivities[n], share)
-    end
-end
 
 function diagnostic_plots(reference_values, scaled_sensitivities, order)
     days = SAVEAT ./ day
@@ -188,13 +174,17 @@ function diagnostic_plots(reference_values, scaled_sensitivities, order)
 end
 
 reference_values = solve_values(θ_REFERENCE)
-reference_objective = total_phytoplankton(reference_values[:, end])
 gradient = enzyme_gradient(copy(θ_REFERENCE))
 scaled_sensitivities = abs.(θ_REFERENCE .* gradient)
 sensitivity_order = sortperm(scaled_sensitivities; rev = true)
 
-print_parameter_table(reference_objective, θ_REFERENCE, gradient, scaled_sensitivities, sensitivity_order)
 plots = diagnostic_plots(reference_values, scaled_sensitivities, sensitivity_order)
 
+# The reference trajectory shows the simulated total phytoplankton biomass used
+# for the endpoint sensitivity calculation.
+
 plots.trajectory
+
+# The scaled sensitivities rank active parameters by `|θᵢ ∂J/∂θᵢ|`.
+
 plots.scaled_sensitivities

--- a/src/Configuration/community.jl
+++ b/src/Configuration/community.jl
@@ -73,10 +73,10 @@ end
 range of equivalent spherical diameters. `splitting` selects the spacing method,
 for example `:log_splitting` or `:linear_splitting`.
 """
-struct DiameterRangeSpecification{I<:Integer,T} <: AbstractDiameterSpecification
+struct DiameterRangeSpecification{I<:Integer,T1,T2} <: AbstractDiameterSpecification
     n::I
-    min_diameter::T
-    max_diameter::T
+    min_diameter::T1
+    max_diameter::T2
     splitting::Symbol
 end
 

--- a/src/Configuration/interactions_matrices.jl
+++ b/src/Configuration/interactions_matrices.jl
@@ -22,13 +22,13 @@ The inverse maps support fast lookup of axis-local indices from global indices:
 - `global_to_prey[g]` returns `ip` or `0` if `g` is not a prey
 
 """
-struct InteractionMatrices{PM,AM,VI,MI}
+struct InteractionMatrices{PM,AM,VI1,VI2,MI1,MI2}
     palatability::PM
     assimilation::AM
-    consumer_global::VI
-    prey_global::VI
-    global_to_consumer::MI
-    global_to_prey::MI
+    consumer_global::VI1
+    prey_global::VI2
+    global_to_consumer::MI1
+    global_to_prey::MI2
 end
 Adapt.@adapt_structure InteractionMatrices
 

--- a/src/Library/Allometry/interactions.jl
+++ b/src/Library/Allometry/interactions.jl
@@ -13,9 +13,9 @@ Prey traits used by allometric palatability kernels.
   protection and `1` means complete protection in the protected palatability
   kernel.
 """
-struct PalatabilityPreyParameters{T<:Real}
-    diameter::T
-    protection::T
+struct PalatabilityPreyParameters{T1<:Real,T2<:Real}
+    diameter::T1
+    protection::T2
 end
 
 """
@@ -28,10 +28,10 @@ Predator traits used by allometric palatability kernels.
 - `optimum_predator_prey_ratio`: preferred predator:prey diameter ratio.
 - `specificity`: sharpness of the unimodal prey-size preference.
 """
-struct PalatabilityPredatorParameters{T<:Real}
-    diameter::T
-    optimum_predator_prey_ratio::T
-    specificity::T
+struct PalatabilityPredatorParameters{T1<:Real,T2<:Real,T3<:Real}
+    diameter::T1
+    optimum_predator_prey_ratio::T2
+    specificity::T3
 end
 
 """
@@ -54,9 +54,9 @@ Evaluate a power-law allometric scaling against spherical cell volume.
 - `b`: exponent parameter.
 - `diameter`: cell equivalent spherical diameter.
 """
-@inline function allometric_scaling_power(a::T, b::T, diameter::T) where {T<:Real}
-    r = diameter / T(2)
-    volume = (T(4) / T(3)) * T(π) * r^T(3)
+@inline function allometric_scaling_power(a::Real, b::Real, diameter::Real)
+    r = diameter / 2
+    volume = (4 / 3) * π * r^3
     return a * volume^b
 end
 
@@ -79,11 +79,11 @@ Compute unimodal allometric palatability from predator and prey diameters.
 - `predator`: `PalatabilityPredatorParameters(diameter, optimum_predator_prey_ratio, specificity)`.
 """
 @inline function allometric_palatability_unimodal(
-    prey::PalatabilityPreyParameters{T}, predator::PalatabilityPredatorParameters{T}
-) where {T<:Real}
+    prey::PalatabilityPreyParameters, predator::PalatabilityPredatorParameters
+)
     ratio = predator.diameter / prey.diameter
-    width = one(T) + (ratio - predator.optimum_predator_prey_ratio)^T(2)
-    return one(T) / width^predator.specificity
+    width = one(ratio) + (ratio - predator.optimum_predator_prey_ratio)^2
+    return one(width) / width^predator.specificity
 end
 
 """
@@ -100,10 +100,10 @@ Compute unimodal allometric palatability with multiplicative prey protection.
     palatability unchanged, while larger values reduce palatability.
 """
 function allometric_palatability_unimodal_protection(
-    prey::PalatabilityPreyParameters{T}, predator::PalatabilityPredatorParameters{T}
-) where {T<:Real}
+    prey::PalatabilityPreyParameters, predator::PalatabilityPredatorParameters
+)
     base = allometric_palatability_unimodal(prey, predator)
-    return base * (one(T) - prey.protection)
+    return base * (one(prey.protection) - prey.protection)
 end
 
 """
@@ -148,11 +148,11 @@ function palatability_matrix_allometric_axes(
     M = zeros(T, nr, nc)
 
     @inbounds for (ii, pred) in pairs(consumer_indices)
-        predator = PalatabilityPredatorParameters{T}(
+        predator = PalatabilityPredatorParameters(
             diameters[pred], optimum_predator_prey_ratio[pred], specificity[pred]
         )
         for (jj, prey) in pairs(prey_indices)
-            prey_params = PalatabilityPreyParameters{T}(diameters[prey], protection[prey])
+            prey_params = PalatabilityPreyParameters(diameters[prey], protection[prey])
             M[ii, jj] = palatability_fn(prey_params, predator)
         end
     end

--- a/src/Library/photosynthesis.jl
+++ b/src/Library/photosynthesis.jl
@@ -27,9 +27,9 @@ Callable Smith (1936) light-limitation factor as a function of PAR.
     0 °C. The returned factor is dimensionless and is multiplied by ``\\mu_0``
     in `smith_growth`.
 """
-struct SmithLightLimitation{T}
-    alpha::T
-    maximum_growth_0C::T
+struct SmithLightLimitation{T1,T2}
+    alpha::T1
+    maximum_growth_0C::T2
 end
 
 @inline function (f::SmithLightLimitation)(PAR)
@@ -56,10 +56,10 @@ Callable Geider-style light-dependent carbon fixation rate.
     specific initial slope, and ``\\theta^C`` is the chlorophyll-to-carbon ratio.
     This follows the Geider et al. light response used by DARWIN-style growth.
 """
-struct GeiderLightLimitation{T}
-    alpha::T
-    maximum_growth_rate::T
-    chlorophyll_to_carbon_ratio::T
+struct GeiderLightLimitation{T1,T2,T3}
+    alpha::T1
+    maximum_growth_rate::T2
+    chlorophyll_to_carbon_ratio::T3
 end
 
 @inline function (f::GeiderLightLimitation)(PAR)

--- a/src/Library/predation.jl
+++ b/src/Library/predation.jl
@@ -51,9 +51,9 @@ Idealized loss rate of prey `P` to a predator `Z` using a squared Holling term.
     - K = prey half-saturation
     - Z = predator concentration
 """
-struct IdealizedPredationLoss{T}
-    maximum_grazing_rate::T
-    half_saturation::T
+struct IdealizedPredationLoss{T1,T2}
+    maximum_grazing_rate::T1
+    half_saturation::T2
 end
 
 @inline function (f::IdealizedPredationLoss)(P, Z)
@@ -78,10 +78,10 @@ Assimilated gain rate to predator `Z` from prey `P`.
     - β = assimilation efficiency
     - g = `IdealizedPredationLoss(gₘₐₓ, K)(P, Z)`
 """
-struct IdealizedPredationGain{T}
-    assimilation_efficiency::T
-    maximum_grazing_rate::T
-    half_saturation::T
+struct IdealizedPredationGain{T1,T2,T3}
+    assimilation_efficiency::T1
+    maximum_grazing_rate::T2
+    half_saturation::T3
 end
 
 @inline function (f::IdealizedPredationGain)(P, Z)
@@ -104,10 +104,10 @@ Unassimilated fraction of idealized predation loss ("sloppy feeding").
 !!! note
     This represents transfer of biomass from prey to the environment rather than to the predator.
 """
-struct IdealizedPredationAssimilationLoss{T}
-    assimilation_efficiency::T
-    maximum_grazing_rate::T
-    half_saturation::T
+struct IdealizedPredationAssimilationLoss{T1,T2,T3}
+    assimilation_efficiency::T1
+    maximum_grazing_rate::T2
+    half_saturation::T3
 end
 
 @inline function (f::IdealizedPredationAssimilationLoss)(P, Z)
@@ -131,10 +131,10 @@ Preferential predation loss from prey `P` to predator `Z`.
     - K = prey half-saturation
     - Z = predator concentration
 """
-struct PreferentialPredationLoss{T}
-    maximum_grazing_rate::T
-    half_saturation::T
-    palatability::T
+struct PreferentialPredationLoss{T1,T2,T3}
+    maximum_grazing_rate::T1
+    half_saturation::T2
+    palatability::T3
 end
 
 @inline function (f::PreferentialPredationLoss)(P, Z)
@@ -153,11 +153,11 @@ Assimilated preferential predation gain.
     - β = assimilation efficiency
     - g = `PreferentialPredationLoss(gₘₐₓ, K, η)(P, Z)`
 """
-struct PreferentialPredationGain{T}
-    assimilation_efficiency::T
-    maximum_grazing_rate::T
-    half_saturation::T
-    palatability::T
+struct PreferentialPredationGain{T1,T2,T3,T4}
+    assimilation_efficiency::T1
+    maximum_grazing_rate::T2
+    half_saturation::T3
+    palatability::T4
 end
 
 @inline function (f::PreferentialPredationGain)(P, Z)
@@ -184,11 +184,11 @@ Unassimilated fraction of preferential predation loss ("sloppy feeding").
 !!! info
     This represents transfer of biomass from prey to the environment rather than to the predator.
 """
-struct PreferentialPredationAssimilationLoss{T}
-    assimilation_efficiency::T
-    maximum_grazing_rate::T
-    half_saturation::T
-    palatability::T
+struct PreferentialPredationAssimilationLoss{T1,T2,T3,T4}
+    assimilation_efficiency::T1
+    maximum_grazing_rate::T2
+    half_saturation::T3
+    palatability::T4
 end
 
 @inline function (f::PreferentialPredationAssimilationLoss)(P, Z)

--- a/src/Runtime/active_parameters.jl
+++ b/src/Runtime/active_parameters.jl
@@ -84,13 +84,17 @@ end
     ParameterizedBGC(Adapt.adapt(to, bgc_p.bgc), Adapt.adapt(to, bgc_p.parameters))
 
 
-@inline function evaluate_tendency(bgc, parameters, ::Val{tracer}, args...) where {tracer}
-    f = getfield(bgc.tracer_functions, tracer)
-    return f(ParameterizedBGC(bgc, parameters), args...)
+@inline function evaluate_tendency(bgc_p::ParameterizedBGC, ::Val{tracer}, args...) where {tracer}
+    f = getfield(bgc_p.bgc.tracer_functions, tracer)
+    return f(bgc_p, args...)
+end
+
+@inline function evaluate_tendency(bgc, parameters, val_name::Val, args...)
+    return evaluate_tendency(ParameterizedBGC(bgc, parameters), val_name, args...)
 end
 
 @inline function (bgc_p::ParameterizedBGC)(val_name::Val, args...)
-    return evaluate_tendency(bgc_p.bgc, bgc_p.parameters, val_name, args...)
+    return evaluate_tendency(bgc_p, val_name, args...)
 end
 
 """Selected active parameters for a BGC.

--- a/src/Runtime/ode_problem.jl
+++ b/src/Runtime/ode_problem.jl
@@ -16,29 +16,58 @@ function ode_problem(
     end
 
     aux_names = required_biogeochemical_auxiliary_fields(bgc)
+    aux_source = ode_auxiliary_source(aux_names, auxiliary)
     tracer_names = required_biogeochemical_tracers(bgc)
 
-    function rhs!(du, u, parameters_vector, t)
-        parameters = isempty(active_map) ? bgc.parameters : ActiveParameters(bgc.parameters, parameters_vector, active_map)
-        aux_values = ode_auxiliary_values(aux_names, auxiliary, t)
-        x, y, z = coordinates
+    if isempty(active_map)
+        parameterized_bgc = ParameterizedBGC(bgc, bgc.parameters)
 
-        for (n, tracer) in enumerate(tracer_names)
-            du[n] = evaluate_tendency(bgc, parameters, Val(tracer), x, y, z, t, u..., aux_values...)
+        rhs! = function (du, u, parameters_vector, t)
+            aux_values = ode_auxiliary_values(aux_source, t)
+            ode_tendencies!(du, parameterized_bgc, tracer_names, coordinates, u, aux_values, t)
+            return nothing
         end
-
-        return nothing
+    else
+        rhs! = function (du, u, parameters_vector, t)
+            parameters = ActiveParameters(bgc.parameters, parameters_vector, active_map)
+            parameterized_bgc = ParameterizedBGC(bgc, parameters)
+            aux_values = ode_auxiliary_values(aux_source, t)
+            ode_tendencies!(du, parameterized_bgc, tracer_names, coordinates, u, aux_values, t)
+            return nothing
+        end
     end
 
     return p === nothing ? ODEProblem(rhs!, u0, tspan) : ODEProblem(rhs!, u0, tspan, p)
 end
 
-function ode_auxiliary_values(aux_names, auxiliary::NamedTuple, t)
-    return map(aux_names) do name
+@inline function ode_tendencies!(du, bgc, tracer_names, coordinates, u, aux_values, t)
+    x, y, z = coordinates
+
+    for (n, tracer) in enumerate(tracer_names)
+        du[n] = evaluate_tendency(bgc, Val(tracer), x, y, z, t, u..., aux_values...)
+    end
+
+    return nothing
+end
+
+struct ODEAuxiliarySource{V,E}
+    values::V
+end
+
+function ode_auxiliary_source(aux_names, auxiliary::NamedTuple)
+    values = map(aux_names) do name
         hasproperty(auxiliary, name) || throw(ArgumentError("Missing auxiliary value :$name."))
-        value = getproperty(auxiliary, name)
-        return value isa Function ? value(t) : value
+        return getproperty(auxiliary, name)
+    end
+    return ODEAuxiliarySource{typeof(values), true}(values)
+end
+
+ode_auxiliary_source(aux_names, auxiliary::Tuple) = ODEAuxiliarySource{typeof(auxiliary), false}(auxiliary)
+
+@inline function ode_auxiliary_values(source::ODEAuxiliarySource{V, true}, t) where {V}
+    return map(source.values) do value
+        value isa Function ? value(t) : value
     end
 end
 
-ode_auxiliary_values(aux_names, auxiliary::Tuple, t) = auxiliary
+@inline ode_auxiliary_values(source::ODEAuxiliarySource{V, false}, t) where {V} = source.values

--- a/test/test_forwarddiff.jl
+++ b/test/test_forwarddiff.jl
@@ -44,6 +44,42 @@ using Oceananigans.Units: day
     @test isapprox(dP1_dmu, fd; rtol=1e-4, atol=1e-10)
 end
 
+@testset "ForwardDiff NiPiZD ode_problem active parameter smoke test" begin
+    mu0 = 0.7 / day
+    base_bgc = ForwardDiffNiPiZD.construct(;
+        parameters=(; maximum_growth_rate=(P1=mu0, P2=mu0)),
+    )
+
+    active_growth = Agate.Runtime.active_parameters(base_bgc; maximum_growth_rate=(:P1,))
+    u0 = [7.0, 1.0, 0.05, 0.05, 0.01, 0.01]
+    problem = Agate.Runtime.ode_problem(
+        base_bgc,
+        u0,
+        (0.0, day);
+        p=copy(active_growth.values),
+        active_parameters=active_growth,
+        auxiliary=(; PAR=100.0),
+    )
+
+    function p1_tendency_with_active_growth_rate(mu)
+        T = typeof(mu)
+        u = T.(u0)
+        du = similar(u)
+        problem.f(du, u, [mu], zero(T))
+        return du[5]
+    end
+
+    dP1_dmu = ForwardDiff.derivative(p1_tendency_with_active_growth_rate, mu0)
+    @test isfinite(dP1_dmu)
+
+    δ = mu0 * 1e-6
+    fd = (
+        p1_tendency_with_active_growth_rate(mu0 + δ) -
+        p1_tendency_with_active_growth_rate(mu0 - δ)
+    ) / (2δ)
+    @test isapprox(dP1_dmu, fd; rtol=1e-4, atol=1e-10)
+end
+
 @testset "ForwardDiff DARWIN tendency smoke tests" begin
     function p1_tendency_with_growth_rate(mu)
         T = typeof(mu)


### PR DESCRIPTION
Release notes:

- Fixes ForwardDiff failures caused by parameter structs that required multiple numeric fields to share the same concrete type.
- Updates the forward-mode AD sensitivity example to use `Agate.Runtime.ode_problem`.
- Adds safer `ode_problem` internals for active parameters, including separate active/inactive RHS paths and reduced wrapper overhead.
- Renames forward- and reverse-mode AD examples/pages for consistent documentation.
- Fixes reverse-mode AD documentation figure rendering and simplified the page output.