### PR TITLE
Named plankton groups

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -24,6 +24,7 @@ const BUILD_COLUMN_EXAMPLE = lowercase(get(ENV, "AGATE_DOCS_BUILD_COLUMN", get(E
 examples = [
     "Size structure" => "size_structure",
     "Predator-prey palatability" => "predator_prey_palatability",
+    "Comparing phytoplankton light strategies" => "named_plankton_groups",
     "Exporting a model setup" => "export_model_setup",
 ]
 

--- a/examples/named_plankton_groups.jl
+++ b/examples/named_plankton_groups.jl
@@ -1,0 +1,159 @@
+# # [Comparing phytoplankton light strategies] (@id named_plankton_groups_example)
+
+# Plankton are highly diverse, and representing some of this diversity can be
+# important in ecosystem models. One important axis of variation is adaptation to
+# the light environment, which can differ both between and within species.
+# High- and low-light-adapted *Prochlorococcus* ecotypes provide a well-known 
+# example of this ecological differentiation.
+#
+# Here, we use this idea to construct two idealized phytoplankton functional types
+# with the same cell size but different light-response traits. This allows us to
+# isolate the effect of light adaptation and explore how the two functional types
+# respond under low- and high-light conditions.
+#
+# The `low_light` type has a lower maximum growth rate but a steeper initial light-response
+# slope than `high_light`. We place the same community in two otherwise identical box models,
+# differing only in photosynthetically active radiation (PAR), and compare which type is more competitive
+# in each light environment.
+
+# ## Loading dependencies
+# The example uses Agate.jl, Oceananigans.jl, and OceanBioME.jl for the ecosystem simulations.
+# CairoMakie.jl is used for plotting.
+
+using Agate
+using Agate.Introspection: tracer_names
+using Agate.Library.Light
+using OceanBioME
+using OceanBioME: Biogeochemistry
+using Oceananigans
+using Oceananigans.Units
+using CairoMakie
+
+nothing #hide
+
+# ## Ecosystem model
+
+# Named groups are defined separately for the phytoplankton and zooplankton roles. Both
+# phytoplankton types use the same diameter so their different behavior comes from the trait
+# overrides rather than from size-dependent defaults.
+
+size_structure = (;
+    phytoplankton=(high_light=[0.7], low_light=[0.7]),
+    zooplankton=(grazer=[30.0],),
+)
+nothing #hide
+
+# The two phytoplankton types are given a simple growth trade-off. `high_light` has the larger
+# maximum growth rate, while `low_light` has the larger `alpha`, the initial slope of the Smith
+# photosynthesis-irradiance curve. The parameter values are illustrative and chosen so that
+# `low_light` grows faster at low PAR and `high_light` grows faster at high PAR.
+
+parameters = (;
+    maximum_growth_rate=(high_light_1=2.0 / day, low_light_1=1.4 / day),
+    alpha=(high_light_1=0.15 / day, low_light_1=0.30 / day),
+)
+
+bgc = Agate.Models.NiPiZD.construct(; size_structure, parameters)
+nothing #hide
+
+# The named groups are realized as deterministic tracer names.
+
+println(tracer_names(bgc))
+
+# ## Light treatments
+
+# We compare a low-light treatment at PAR = 5 with a high-light treatment at PAR = 20.
+# Every other part of the ecosystem setup is shared between the two simulations.
+
+low_PAR = 5.0
+high_PAR = 100.0
+
+# ## Run the box models
+
+function run_light_treatment(bgc, PAR, filename)
+    grid = BoxModelGrid()
+    constant_PAR = t -> PAR
+    light_attenuation = FunctionFieldPAR(; grid, PAR_f=constant_PAR)
+    bgc_model = Biogeochemistry(bgc; light_attenuation)
+    full_model = BoxModel(; biogeochemistry=bgc_model)
+
+    set!(
+        full_model;
+        N=20.0,
+        D=0.0,
+        grazer_1=0.0,
+        high_light_1=0.01,
+        low_light_1=0.01,
+    )
+
+    simulation = Simulation(full_model; Δt=60minutes, stop_time=3days)
+
+    simulation.output_writers[:fields] = JLD2Writer(
+        full_model,
+        full_model.fields;
+        filename,
+        schedule=TimeInterval(1hour),
+        overwrite_existing=true,
+    )
+
+    run!(simulation)
+
+    return filename
+end
+
+low_filename = run_light_treatment(bgc, low_PAR, "named_groups_low_light.jld2")
+high_filename = run_light_treatment(bgc, high_PAR, "named_groups_high_light.jld2")
+
+nothing #hide
+
+# ## Load the output time series
+
+function phytoplankton_timeseries(filename)
+    high_light = FieldTimeSeries(filename, "high_light_1")[1, 1, 1, :]
+    low_light = FieldTimeSeries(filename, "low_light_1")[1, 1, 1, :]
+    times = FieldTimeSeries(filename, "high_light_1").times
+    return (; times, high_light, low_light)
+end
+
+low = phytoplankton_timeseries(low_filename)
+high = phytoplankton_timeseries(high_filename)
+nothing #hide
+
+# ## Compare the light treatments
+
+# Both simulations start with equal phytoplankton biomass. Under low PAR, the steeper initial
+# light-response slope favors `low_light`. Under high PAR, the larger maximum growth rate favors
+# `high_light`.
+
+fig = Figure(; size=(900, 420), fontsize=14)
+
+for (column, treatment, PAR) in ((1, low, low_PAR), (2, high, high_PAR))
+    ax = Axis(
+        fig[1, column];
+        xlabel="Time (days)",
+        ylabel="Concentration (mmol N / m³)",
+        title="PAR = $(PAR)",
+    )
+
+    lines!(
+        ax,
+        treatment.times / day,
+        treatment.high_light;
+        label="high_light",
+        linewidth=2,
+    )
+    lines!(
+        ax,
+        treatment.times / day,
+        treatment.low_light;
+        label="low_light",
+        linewidth=2,
+    )
+    axislegend(ax; position=:lt)
+end
+
+Label(fig[0, 1:2], "Contrasting responses to low and high light"; fontsize=20)
+
+save("named_plankton_groups.png", fig; px_per_unit=1)
+
+fig

--- a/examples/named_plankton_groups.jl
+++ b/examples/named_plankton_groups.jl
@@ -3,7 +3,7 @@
 # Plankton are highly diverse, and representing some of this diversity can be
 # important in ecosystem models. One important axis of variation is adaptation to
 # the light environment, which can differ both between and within species.
-# High- and low-light-adapted *Prochlorococcus* ecotypes provide a well-known 
+# High- and low-light-adapted *Prochlorococcus* ecotypes provide a well-known
 # example of this ecological differentiation.
 #
 # Here, we use this idea to construct two idealized phytoplankton functional types
@@ -13,8 +13,8 @@
 #
 # The `low_light` type has a lower maximum growth rate but a steeper initial light-response
 # slope than `high_light`. We place the same community in two otherwise identical box models,
-# differing only in photosynthetically active radiation (PAR), and compare which type is more competitive
-# in each light environment.
+# differing only in photosynthetically active radiation (PAR), and compare which type is more
+# competitive in each light environment.
 
 # ## Loading dependencies
 # The example uses Agate.jl, Oceananigans.jl, and OceanBioME.jl for the ecosystem simulations.
@@ -62,7 +62,7 @@ println(tracer_names(bgc))
 
 # ## Light treatments
 
-# We compare a low-light treatment at PAR = 5 with a high-light treatment at PAR = 20.
+# We compare a low-light treatment at PAR = 5 with a high-light treatment at PAR = 100.
 # Every other part of the ecosystem setup is shared between the two simulations.
 
 low_PAR = 5.0

--- a/src/Configuration/community.jl
+++ b/src/Configuration/community.jl
@@ -150,6 +150,12 @@ normalize_diameters(spec::DiameterRangeSpecification) = (; n=spec.n, specificati
 
 normalize_diameters(spec) = throw(ArgumentError("invalid `diameters` specification"))
 
+_tracer_names_issue(names, group, n) =
+    !(names isa Tuple || names isa AbstractVector) ? "group $group: `tracer_names` must be a Tuple or AbstractVector" :
+    !all(name -> name isa Symbol, names) ? "group $group: `tracer_names` entries must be Symbols" :
+    !isnothing(n) && length(names) != n ? "group $group: `tracer_names` must have length $n" :
+    nothing
+
 """Validate `plankton_dynamics` and `community` inputs.
 
 Throws a single `ArgumentError` listing all issues.
@@ -233,16 +239,9 @@ function validate_community_inputs(plankton_dynamics, community)
 
         if hasproperty(spec, :tracer_names)
             names = getproperty(spec, :tracer_names)
-            if !(names isa Tuple || names isa AbstractVector)
-                push!(issues, "group $(k): `tracer_names` must be a Tuple or AbstractVector")
-            elseif !all(name -> name isa Symbol, names)
-                push!(issues, "group $(k): `tracer_names` entries must be Symbols")
-            elseif hasproperty(spec, :n) && length(names) != getproperty(spec, :n)
-                push!(
-                    issues,
-                    "group $(k): `tracer_names` must have length $(getproperty(spec, :n))",
-                )
-            end
+            n = hasproperty(spec, :n) ? getproperty(spec, :n) : nothing
+            issue = _tracer_names_issue(names, k, n)
+            isnothing(issue) || push!(issues, issue)
         end
     end
 
@@ -325,9 +324,8 @@ function parse_community(
 
         class_symbols = if hasproperty(spec, :tracer_names)
             names = getproperty(spec, :tracer_names)
-            length(names) == n || throw(
-                ArgumentError("group $g: `tracer_names` must have length $n")
-            )
+            issue = _tracer_names_issue(names, g, n)
+            isnothing(issue) || throw(ArgumentError(issue))
             Symbol[names...]
         else
             Symbol[Symbol(string(g), i) for i in 1:n]

--- a/src/Configuration/community.jl
+++ b/src/Configuration/community.jl
@@ -93,7 +93,7 @@ Fields
 - `n_total`: total number of plankton classes.
 - `diameters`: flattened diameter vector in global plankton order.
 - `pfts`: per-class PFT specifications.
-- `plankton_symbols`: flattened class symbols such as `:P1`, `:P2`.
+- `plankton_symbols`: flattened class symbols such as `:P1`, `:P2`, or `:diat_1`.
 - `group_symbols`: group symbol for each flattened class.
 - `group_local_index`: within-group class index for each flattened class.
 - `group_indices`: mapping from group symbol to flattened class indices.
@@ -230,6 +230,20 @@ function validate_community_inputs(plankton_dynamics, community)
             ok = pft isa PFTSpecification || pft isa NamedTuple
             ok || push!(issues, "group $(k): `pft` must be PFTSpecification or NamedTuple")
         end
+
+        if hasproperty(spec, :tracer_names)
+            names = getproperty(spec, :tracer_names)
+            if !(names isa Tuple || names isa AbstractVector)
+                push!(issues, "group $(k): `tracer_names` must be a Tuple or AbstractVector")
+            elseif !all(name -> name isa Symbol, names)
+                push!(issues, "group $(k): `tracer_names` entries must be Symbols")
+            elseif hasproperty(spec, :n) && length(names) != getproperty(spec, :n)
+                push!(
+                    issues,
+                    "group $(k): `tracer_names` must have length $(getproperty(spec, :n))",
+                )
+            end
+        end
     end
 
     if !isempty(issues)
@@ -309,14 +323,35 @@ function parse_community(
         pft_raw = getproperty(spec, :pft)
         pft = pft_raw isa PFTSpecification ? pft_raw : PFTSpecification(pft_raw)
 
+        class_symbols = if hasproperty(spec, :tracer_names)
+            names = getproperty(spec, :tracer_names)
+            length(names) == n || throw(
+                ArgumentError("group $g: `tracer_names` must have length $n")
+            )
+            Symbol[names...]
+        else
+            Symbol[Symbol(string(g), i) for i in 1:n]
+        end
+
         for i in 1:n
-            push!(plankton_symbols, Symbol(string(g), i))
+            push!(plankton_symbols, class_symbols[i])
             push!(group_of, g)
             push!(local_idx, i)
             push!(pfts, pft)
             push!(diameters, ds[i])
         end
     end
+
+    length(unique(plankton_symbols)) == length(plankton_symbols) ||
+        throw(ArgumentError("plankton tracer names must be unique"))
+
+    biogeochem_symbols = Set(keys(biogeochem_dynamics))
+    conflicting_symbols = [symbol for symbol in plankton_symbols if symbol in biogeochem_symbols]
+    isempty(conflicting_symbols) || throw(
+        ArgumentError(
+            "plankton tracer names conflict with non-plankton tracers: $(unique(conflicting_symbols))"
+        ),
+    )
 
     n_total = length(plankton_symbols)
 

--- a/src/Manifests/Manifests.jl
+++ b/src/Manifests/Manifests.jl
@@ -52,8 +52,43 @@ end
 construct_from_manifest(path::AbstractString; grid=nothing, arch=nothing) =
     construct_from_manifest(JSON.parsefile(path); grid, arch)
 
-function default_model_manifest(family::Symbol, data)
+function manifest_group_entries(groups, diameters_by_group)
+    return Any[
+        Dict{String,Any}(
+            "name" => string(group),
+            "diameters" => diameters_by_group[string(group)],
+        ) for group in groups
+    ]
+end
+
+function manifest_size_structure(group_roles, diameters_by_group)
+    return Dict{String,Any}(
+        "phytoplankton" => manifest_group_entries(
+            group_roles.phytoplankton, diameters_by_group
+        ),
+        "zooplankton" => manifest_group_entries(
+            group_roles.zooplankton, diameters_by_group
+        ),
+    )
+end
+
+function default_model_manifest(family::Symbol, data; group_roles=nothing)
     family_name = string(family)
+    kwargs = Dict{String,Any}(
+        "parameters" => data.parameter_values,
+        "sinking_tracers" => data.sinking_tracers,
+        "open_bottom" => data.open_bottom,
+        "scalar_type" => data.scalar_type,
+    )
+
+    if isnothing(group_roles)
+        kwargs["phyto_size_structure"] = data.plankton_diameters_by_group["P"]
+        kwargs["zoo_size_structure"] = data.plankton_diameters_by_group["Z"]
+    else
+        kwargs["size_structure"] =
+            manifest_size_structure(group_roles, data.plankton_diameters_by_group)
+    end
+
     return Dict{String,Any}(
         "schema" => MODEL_SETUP_SCHEMA,
         "created_at" => string(now(UTC)),
@@ -62,14 +97,7 @@ function default_model_manifest(family::Symbol, data)
             "julia_version" => string(VERSION),
         ),
         "model" => Dict{String,Any}("family" => family_name),
-        "kwargs" => Dict{String,Any}(
-            "phyto_size_structure" => data.plankton_diameters_by_group["P"],
-            "zoo_size_structure" => data.plankton_diameters_by_group["Z"],
-            "parameters" => data.parameter_values,
-            "sinking_tracers" => data.sinking_tracers,
-            "open_bottom" => data.open_bottom,
-            "scalar_type" => data.scalar_type,
-        ),
+        "kwargs" => kwargs,
     )
 end
 
@@ -92,13 +120,18 @@ function constructor_kwargs(setup::AbstractDict; grid=nothing, arch=nothing)
 
     pairs = Pair{Symbol,Any}[]
 
+    haskey(kwargs, "size_structure") &&
+        push!(pairs, :size_structure => named_size_structure_kwargs(kwargs["size_structure"]))
     for key in ("phyto_size_structure", "zoo_size_structure", "open_bottom")
         haskey(kwargs, key) && push!(pairs, Symbol(key) => setup_value(kwargs[key]))
     end
 
-    haskey(kwargs, "parameters") && push!(pairs, :parameters => parameter_kwargs(kwargs["parameters"]))
-    haskey(kwargs, "sinking_tracers") && push!(pairs, :sinking_tracers => sinking_tracers_kwargs(kwargs["sinking_tracers"]))
-    haskey(kwargs, "scalar_type") && push!(pairs, :scalar_type => decode_scalar_type(kwargs["scalar_type"]))
+    haskey(kwargs, "parameters") &&
+        push!(pairs, :parameters => parameter_kwargs(kwargs["parameters"]))
+    haskey(kwargs, "sinking_tracers") &&
+        push!(pairs, :sinking_tracers => sinking_tracers_kwargs(kwargs["sinking_tracers"]))
+    haskey(kwargs, "scalar_type") &&
+        push!(pairs, :scalar_type => decode_scalar_type(kwargs["scalar_type"]))
 
     !isnothing(grid) && push!(pairs, :grid => grid)
     !isnothing(arch) && push!(pairs, :arch => arch)
@@ -108,6 +141,26 @@ end
 
 function parameter_kwargs(parameters::AbstractDict)
     return (; (Symbol(k) => parameter_value(v) for (k, v) in pairs(parameters))...)
+end
+
+function named_size_structure_kwargs(size_structure::AbstractDict)
+    return (;
+        phytoplankton=named_role_size_structure(size_structure, "phytoplankton"),
+        zooplankton=named_role_size_structure(size_structure, "zooplankton"),
+    )
+end
+
+function named_size_structure_kwargs(size_structure)
+    throw(ArgumentError("Model setup size_structure must be an object."))
+end
+
+function named_role_size_structure(size_structure::AbstractDict, role::AbstractString)
+    groups = get(size_structure, role, nothing)
+    groups isa AbstractVector ||
+        throw(ArgumentError("Model setup size_structure.$role must be an array."))
+    return (;
+        (Symbol(group["name"]) => setup_value(group["diameters"]) for group in groups)...
+    )
 end
 
 function sinking_tracers_kwargs(sinking)

--- a/src/Models/DARWIN/factory.jl
+++ b/src/Models/DARWIN/factory.jl
@@ -55,7 +55,7 @@ end
 
 Returns a `NamedTuple` mapping group prefix => group specification.
 
-Ordering is significant; the default keeps the historical `Z`-then-`P` ordering.
+Ordering is significant; the default uses `Z`-then-`P` ordering.
 """
 function default_community(::DarwinFactory)
     # Structural defaults only (sizes/diameters). No parameter defaults.

--- a/src/Models/NiPiZD/factory.jl
+++ b/src/Models/NiPiZD/factory.jl
@@ -52,7 +52,7 @@ end
 
 Returns a `NamedTuple` mapping group prefix => group specification.
 
-Ordering is significant; the default keeps the historical `Z`-then-`P` ordering.
+Ordering is significant; the default uses `Z`-then-`P` ordering.
 """
 function default_community(::NiPiZDFactory)
     # Structural defaults only (sizes/diameters). No parameter defaults.

--- a/src/Models/NiPiZD/interface.jl
+++ b/src/Models/NiPiZD/interface.jl
@@ -81,7 +81,10 @@ function _named_community_inputs(size_structure)
     plankton_dynamics = NamedTuple{group_order}(dynamics_values)
     interaction_roles = (consumers=named.consumer_groups, prey=named.producer_groups)
 
-    return (; community, plankton_dynamics, interaction_roles)
+    group_roles = (;
+        phytoplankton=named.producer_groups, zooplankton=named.consumer_groups
+    )
+    return (; community, plankton_dynamics, interaction_roles, group_roles)
 end
 
 function _construction_inputs(;
@@ -112,6 +115,7 @@ function _construction_inputs(;
             community,
             plankton_dynamics=Factories.default_plankton_dynamics(factory),
             interaction_roles=(consumers=(:Z,), prey=(:P,)),
+            group_roles=nothing,
         )
     else
         (isnothing(phyto_size_structure) && isnothing(zoo_size_structure)) || throw(
@@ -132,6 +136,7 @@ function _construction_inputs(;
 
     return (
         factory=factory,
+        manifest_group_roles=community_inputs.group_roles,
         kwargs=(;
             plankton_dynamics=community_inputs.plankton_dynamics,
             community=community_inputs.community,
@@ -253,12 +258,15 @@ end
     construct_with_manifest(; kw...) -> bgc, manifest
 
 Construct a model instance and return it with a JSON-compatible model setup manifest.
+Named groups are recorded in role/group order with their resolved class diameters.
 """
 function construct_with_manifest(; kwargs...)
     inputs = _construction_inputs(; kwargs...)
     bgc, manifest_data = Construction.construct_factory_with_manifest_data(
         inputs.factory; inputs.kwargs...
     )
-    manifest = default_model_manifest(:NiPiZD, manifest_data)
+    manifest = default_model_manifest(
+        :NiPiZD, manifest_data; group_roles=inputs.manifest_group_roles
+    )
     return bgc, manifest
 end

--- a/src/Models/NiPiZD/interface.jl
+++ b/src/Models/NiPiZD/interface.jl
@@ -8,9 +8,79 @@ using ...Manifests: default_model_manifest
 
 export construct, construct_with_manifest
 
+const DEFAULT_PHYTO_SIZE_STRUCTURE =
+    (n=2, min_esd=2, max_esd=10, splitting=:log_splitting)
+const DEFAULT_ZOO_SIZE_STRUCTURE =
+    (n=2, min_esd=20, max_esd=100, splitting=:linear_splitting)
+
+function _named_size_structure(size_structure)
+    size_structure isa NamedTuple ||
+        throw(ArgumentError("size_structure must be a NamedTuple"))
+
+    required_roles = (:phytoplankton, :zooplankton)
+    missing_roles = [role for role in required_roles if !hasproperty(size_structure, role)]
+    extra_roles = [role for role in keys(size_structure) if !(role in required_roles)]
+    isempty(missing_roles) || throw(
+        ArgumentError("size_structure is missing roles: $(collect(missing_roles))")
+    )
+    isempty(extra_roles) ||
+        throw(ArgumentError("size_structure has unknown roles: $(collect(extra_roles))"))
+
+    phytoplankton = size_structure.phytoplankton
+    zooplankton = size_structure.zooplankton
+    phytoplankton isa NamedTuple ||
+        throw(ArgumentError("size_structure.phytoplankton must be a NamedTuple"))
+    zooplankton isa NamedTuple ||
+        throw(ArgumentError("size_structure.zooplankton must be a NamedTuple"))
+    isempty(phytoplankton) &&
+        throw(ArgumentError("size_structure.phytoplankton must define at least one group"))
+    isempty(zooplankton) &&
+        throw(ArgumentError("size_structure.zooplankton must define at least one group"))
+
+    producer_groups = keys(phytoplankton)
+    consumer_groups = keys(zooplankton)
+    duplicate_groups = [group for group in producer_groups if group in consumer_groups]
+    isempty(duplicate_groups) || throw(
+        ArgumentError(
+            "plankton group names must be unique across roles; " *
+            "duplicated groups: $(collect(duplicate_groups))",
+        ),
+    )
+
+    return (; phytoplankton, zooplankton, producer_groups, consumer_groups)
+end
+
+function _named_community_inputs(size_structure)
+    named = _named_size_structure(size_structure)
+    group_order = (named.consumer_groups..., named.producer_groups...)
+    empty_pft = Configuration.PFTSpecification()
+
+    community_base_values = ntuple(length(group_order)) do i
+        group = group_order[i]
+        diameters = if group in named.consumer_groups
+            getproperty(named.zooplankton, group)
+        else
+            getproperty(named.phytoplankton, group)
+        end
+        return (; diameters, pft=empty_pft)
+    end
+    community_base = NamedTuple{group_order}(community_base_values)
+    community = Configuration.build_plankton_community(community_base)
+
+    dynamics_values = ntuple(length(group_order)) do i
+        group = group_order[i]
+        return group in named.consumer_groups ? zooplankton_nipizd : phytoplankton_nipizd
+    end
+    plankton_dynamics = NamedTuple{group_order}(dynamics_values)
+    interaction_roles = (consumers=named.consumer_groups, prey=named.producer_groups)
+
+    return (; community, plankton_dynamics, interaction_roles)
+end
+
 function _construction_inputs(;
-    phyto_size_structure=(n=2, min_esd=2, max_esd=10, splitting=:log_splitting),
-    zoo_size_structure=(n=2, min_esd=20, max_esd=100, splitting=:linear_splitting),
+    size_structure=nothing,
+    phyto_size_structure=nothing,
+    zoo_size_structure=nothing,
     parameters::NamedTuple=(;),
     palatability_matrix=nothing,
     assimilation_matrix=nothing,
@@ -22,10 +92,28 @@ function _construction_inputs(;
 )
     factory = NiPiZDFactory()
 
-    base = Factories.default_community(factory)
-    community = Configuration.build_plankton_community(
-        base; diameters=(Z=zoo_size_structure, P=phyto_size_structure)
-    )
+    community_inputs = if isnothing(size_structure)
+        phyto =
+            isnothing(phyto_size_structure) ? DEFAULT_PHYTO_SIZE_STRUCTURE : phyto_size_structure
+        zoo =
+            isnothing(zoo_size_structure) ? DEFAULT_ZOO_SIZE_STRUCTURE : zoo_size_structure
+        base = Factories.default_community(factory)
+        community = Configuration.build_plankton_community(
+            base; diameters=(Z=zoo, P=phyto)
+        )
+        (;
+            community,
+            plankton_dynamics=Factories.default_plankton_dynamics(factory),
+            interaction_roles=(consumers=(:Z,), prey=(:P,)),
+        )
+    else
+        (isnothing(phyto_size_structure) && isnothing(zoo_size_structure)) || throw(
+            ArgumentError(
+                "size_structure cannot be combined with phyto_size_structure or zoo_size_structure",
+            ),
+        )
+        _named_community_inputs(size_structure)
+    end
 
     pairs = Pair{Symbol,Any}[]
     palatability_matrix !== nothing &&
@@ -34,14 +122,14 @@ function _construction_inputs(;
         push!(pairs, :assimilation_matrix => assimilation_matrix)
 
     interaction_overrides = isempty(pairs) ? nothing : (; pairs...)
-    interaction_roles = (consumers=(:Z,), prey=(:P,))
 
     return (
         factory=factory,
         kwargs=(;
-            community=community,
+            plankton_dynamics=community_inputs.plankton_dynamics,
+            community=community_inputs.community,
             parameters=parameters,
-            interaction_roles=interaction_roles,
+            interaction_roles=community_inputs.interaction_roles,
             auxiliary_fields=(:PAR,),
             interaction_overrides=interaction_overrides,
             arch=arch,
@@ -58,8 +146,8 @@ end
 
 Construct a size-structured NiPiZD ecosystem model.
 
-The NiPiZD model contains two plankton groups: phytoplankton (`P`) and zooplankton (`Z`),
-with size classes defined by their size-structure inputs.
+The NiPiZD model contains phytoplankton and zooplankton roles. The default groups are
+`P` and `Z`; `size_structure` may define multiple named groups within either role.
 
 In addition to plankton, the default NiPiZD factory includes idealized nutrient (`N`) and
 detritus (`D`) cycling. The returned biogeochemistry instance includes a photosynthetically
@@ -70,14 +158,20 @@ vectors and interaction matrices (e.g. palatability and assimilation efficiency)
 may override interaction matrices explicitly with `palatability_matrix` and/or
 `assimilation_matrix`.
 
-Size-structure inputs may be a NamedTuple range, for example
+Each group size structure may be a NamedTuple range, for example
 `(n=3, min_esd=1, max_esd=10, splitting=:log_splitting)`, or an explicit
-diameter vector such as `[1.0, 3.2, 10.0]`.
+diameter vector such as `[1.0, 3.2, 10.0]`. Named groups are supplied as
+`size_structure=(phytoplankton=(...), zooplankton=(...))`.
 
 Keywords
 --------
-- `phyto_size_structure=(n=2, min_esd=2, max_esd=10, splitting=:log_splitting)`: phytoplankton size structure
-- `zoo_size_structure=(n=2, min_esd=20, max_esd=100, splitting=:linear_splitting)`: zooplankton size structure
+- `size_structure=nothing`: optional named phytoplankton and zooplankton groups, supplied as a
+  NamedTuple with `phytoplankton` and `zooplankton` fields. When supplied, this defines the
+  plankton community.
+- `phyto_size_structure=nothing`: phytoplankton size structure for the default `P` group. When
+  omitted, uses `(n=2, min_esd=2, max_esd=10, splitting=:log_splitting)`.
+- `zoo_size_structure=nothing`: zooplankton size structure for the default `Z` group. When
+  omitted, uses `(n=2, min_esd=20, max_esd=100, splitting=:linear_splitting)`.
 - `parameters=(;)`: parameter overrides (validated against the NiPiZD parameter set). Vector parameters may be supplied positionally, as partial NamedTuple overrides keyed by plankton class name, or as allometric definitions for diameter-indexed plankton vectors.
 - `palatability_matrix=nothing`: optional palatability matrix override. Must be an explicit rectangular matrix sized to the canonical interaction axes `(n_consumer, n_prey)`.
 - `assimilation_matrix=nothing`: optional assimilation matrix override. Must be an explicit rectangular matrix sized to the canonical interaction axes `(n_consumer, n_prey)`.
@@ -97,6 +191,17 @@ Example
 using Agate.Models: NiPiZD
 
 bgc = NiPiZD.construct()
+```
+
+Named groups may be defined within the two ecological roles:
+
+```julia
+bgc = NiPiZD.construct(;
+    size_structure=(;
+        phytoplankton=(diat=[2.0, 5.0, 10.0], dino=[8.0, 20.0]),
+        zooplankton=(microzoo=[30.0, 60.0], mesozoo=[100.0]),
+    ),
+)
 ```
 
 Trait-style allometric parameter overrides may be supplied during construction:

--- a/src/Models/NiPiZD/interface.jl
+++ b/src/Models/NiPiZD/interface.jl
@@ -207,33 +207,6 @@ using Agate.Models: NiPiZD
 bgc = NiPiZD.construct()
 ```
 
-Named groups may be defined within the two ecological roles:
-
-```julia
-bgc = NiPiZD.construct(;
-    size_structure=(;
-        phytoplankton=(diat=[2.0, 5.0, 10.0], dino=[8.0, 20.0]),
-        zooplankton=(microzoo=[30.0, 60.0], mesozoo=[100.0]),
-    ),
-)
-```
-
-Resolved tracer names can be used for partial parameter overrides. Interaction matrices
-use the realized zooplankton classes as rows and phytoplankton classes as columns:
-
-```julia
-using Oceananigans.Units: day
-
-bgc = NiPiZD.construct(;
-    size_structure=(;
-        phytoplankton=(diat=[2.0, 5.0],),
-        zooplankton=(microzoo=[30.0, 60.0],),
-    ),
-    parameters=(; maximum_growth_rate=(diat_1=1.2 / day,)),
-    palatability_matrix=[0.9 0.7; 0.8 0.6],
-)
-```
-
 Trait-style allometric parameter overrides may be supplied during construction:
 
 ```julia

--- a/src/Models/NiPiZD/interface.jl
+++ b/src/Models/NiPiZD/interface.jl
@@ -181,9 +181,9 @@ Keywords
   omitted, uses `(n=2, min_esd=2, max_esd=10, splitting=:log_splitting)`.
 - `zoo_size_structure=nothing`: zooplankton size structure for the default `Z` group. When
   omitted, uses `(n=2, min_esd=20, max_esd=100, splitting=:linear_splitting)`.
-- `parameters=(;)`: parameter overrides (validated against the NiPiZD parameter set). Vector parameters may be supplied positionally, as partial NamedTuple overrides keyed by plankton class name, or as allometric definitions for diameter-indexed plankton vectors.
-- `palatability_matrix=nothing`: optional palatability matrix override. Must be an explicit rectangular matrix sized to the canonical interaction axes `(n_consumer, n_prey)`.
-- `assimilation_matrix=nothing`: optional assimilation matrix override. Must be an explicit rectangular matrix sized to the canonical interaction axes `(n_consumer, n_prey)`.
+- `parameters=(;)`: parameter overrides (validated against the NiPiZD parameter set). Vector parameters may be supplied positionally, as partial NamedTuple overrides keyed by realized plankton tracer name (for example `diat_1` or `microzoo_1` for named groups), or as allometric definitions for diameter-indexed plankton vectors.
+- `palatability_matrix=nothing`: optional palatability matrix override. Must be an explicit rectangular matrix with rows ordered by realized zooplankton classes and columns ordered by realized phytoplankton classes.
+- `assimilation_matrix=nothing`: optional assimilation matrix override with the same consumer-by-prey class ordering as `palatability_matrix`.
 - `grid=BoxModelGrid()`: grid used for architecture inference and default scalar-type selection
 - `scalar_type=nothing`: explicit runtime scalar type. When omitted, construction uses `eltype(grid)` or `Float64` if no grid is supplied
 - `arch=nothing`: override the architecture (usually inferred from `grid`)
@@ -210,6 +210,22 @@ bgc = NiPiZD.construct(;
         phytoplankton=(diat=[2.0, 5.0, 10.0], dino=[8.0, 20.0]),
         zooplankton=(microzoo=[30.0, 60.0], mesozoo=[100.0]),
     ),
+)
+```
+
+Resolved tracer names can be used for partial parameter overrides. Interaction matrices
+use the realized zooplankton classes as rows and phytoplankton classes as columns:
+
+```julia
+using Oceananigans.Units: day
+
+bgc = NiPiZD.construct(;
+    size_structure=(;
+        phytoplankton=(diat=[2.0, 5.0],),
+        zooplankton=(microzoo=[30.0, 60.0],),
+    ),
+    parameters=(; maximum_growth_rate=(diat_1=1.2 / day,)),
+    palatability_matrix=[0.9 0.7; 0.8 0.6],
 )
 ```
 

--- a/src/Models/NiPiZD/interface.jl
+++ b/src/Models/NiPiZD/interface.jl
@@ -65,7 +65,14 @@ function _named_community_inputs(size_structure)
         return (; diameters, pft=empty_pft)
     end
     community_base = NamedTuple{group_order}(community_base_values)
-    community = Configuration.build_plankton_community(community_base)
+    sized_community = Configuration.build_plankton_community(community_base)
+    community_values = ntuple(length(group_order)) do i
+        group = group_order[i]
+        spec = getproperty(sized_community, group)
+        tracer_names = ntuple(j -> Symbol(string(group), "_", j), spec.n)
+        return (; spec..., tracer_names)
+    end
+    community = NamedTuple{group_order}(community_values)
 
     dynamics_values = ntuple(length(group_order)) do i
         group = group_order[i]
@@ -162,6 +169,8 @@ Each group size structure may be a NamedTuple range, for example
 `(n=3, min_esd=1, max_esd=10, splitting=:log_splitting)`, or an explicit
 diameter vector such as `[1.0, 3.2, 10.0]`. Named groups are supplied as
 `size_structure=(phytoplankton=(...), zooplankton=(...))`.
+Classes in named groups use `<group>_<index>` tracer names, such as `diat_1`.
+The default `P` and `Z` groups use `P1`, `P2`, `Z1`, `Z2`, and so on.
 
 Keywords
 --------

--- a/test/test_active_parameters.jl
+++ b/test/test_active_parameters.jl
@@ -289,3 +289,73 @@ end
 
     @test bgc_p.parameters.interactions.palatability[2, 2] == base_bgc.parameters.interactions.palatability[2, 2]
 end
+
+@testset "named-group runtime active parameters" begin
+    named_bgc = ActiveParameterNiPiZD.construct(;
+        size_structure=(;
+            phytoplankton=(diat=[2.0], dino=[10.0]),
+            zooplankton=(microzoo=[20.0], mesozoo=[100.0]),
+        ),
+    )
+    flat_bgc = ActiveParameterNiPiZD.construct(;
+        phyto_size_structure=[2.0, 10.0],
+        zoo_size_structure=[20.0, 100.0],
+    )
+
+    function runtime_active(bgc, producers, consumers)
+        p1, p2 = producers
+        z1, z2 = consumers
+        return Agate.Runtime.active_parameters(bgc;
+            maximum_growth_rate=(p1, p2),
+            interactions=(;
+                palatability=((z1, p1),),
+                assimilation=((z2, p2),),
+            ),
+        )
+    end
+
+    named_active = runtime_active(
+        named_bgc, (:diat_1, :dino_1), (:microzoo_1, :mesozoo_1)
+    )
+    flat_active = runtime_active(flat_bgc, (:P1, :P2), (:Z1, :Z2))
+
+    @test named_active.labels == (
+        "maximum_growth_rate.diat_1",
+        "maximum_growth_rate.dino_1",
+        "interactions.palatability[microzoo_1, diat_1]",
+        "interactions.assimilation[mesozoo_1, dino_1]",
+    )
+    @test named_active.values == flat_active.values
+
+    p = copy(named_active.values)
+    p[1] *= 1.2
+    p[3] *= 0.8
+    p[4] *= 0.9
+
+    args = (0, 0, 0, 0, 7.0, 1.0, 0.05, 0.05, 0.01, 0.01, 100.0)
+    named_parameterized = Agate.Runtime.parameterized(
+        named_bgc, p; active_parameters=named_active
+    )
+    flat_parameterized = Agate.Runtime.parameterized(
+        flat_bgc, p; active_parameters=flat_active
+    )
+    @test named_parameterized(Val(:diat_1), args...) ≈
+          flat_parameterized(Val(:P1), args...)
+
+    u0 = [7.0, 1.0, 0.05, 0.05, 0.01, 0.01]
+    function rhs(bgc, active)
+        problem = Agate.Runtime.ode_problem(
+            bgc,
+            u0,
+            (0.0, day);
+            p,
+            active_parameters=active,
+            auxiliary=(; PAR=100.0),
+        )
+        du = similar(u0)
+        problem.f(du, u0, p, 0.0)
+        return du
+    end
+
+    @test rhs(named_bgc, named_active) ≈ rhs(flat_bgc, flat_active)
+end

--- a/test/test_introspection.jl
+++ b/test/test_introspection.jl
@@ -78,6 +78,49 @@ using Test
         @test plankton_tracers(sized_bgc) == [:Z1, :Z2, :P1, :P2, :P3]
         @test plankton_diameters(sized_bgc) ≈ [zoo_diameters; phyto_diameters]
 
+        named_bgc = Agate.Models.NiPiZD.construct(;
+            size_structure=(;
+                phytoplankton=(diat=[2.0, 5.0, 10.0], dino=[8.0, 20.0]),
+                zooplankton=(microzoo=[30.0, 60.0], mesozoo=[100.0]),
+            ),
+            grid=dummy_grid(Float32),
+        )
+        @test tracer_names(named_bgc) == [
+            :N,
+            :D,
+            :microzoo_1,
+            :microzoo_2,
+            :mesozoo_1,
+            :diat_1,
+            :diat_2,
+            :diat_3,
+            :dino_1,
+            :dino_2,
+        ]
+
+        named_groups = plankton_groups(named_bgc)
+        @test keys(named_groups) == (:microzoo, :mesozoo, :diat, :dino)
+        @test named_groups.microzoo == [:microzoo_1, :microzoo_2]
+        @test named_groups.mesozoo == [:mesozoo_1]
+        @test named_groups.diat == [:diat_1, :diat_2, :diat_3]
+        @test named_groups.dino == [:dino_1, :dino_2]
+        @test plankton_tracers(named_bgc) == [
+            :microzoo_1,
+            :microzoo_2,
+            :mesozoo_1,
+            :diat_1,
+            :diat_2,
+            :diat_3,
+            :dino_1,
+            :dino_2,
+        ]
+        @test plankton_diameters(named_bgc) ≈
+            [30.0, 60.0, 100.0, 2.0, 5.0, 10.0, 8.0, 20.0]
+
+        named_pal = interaction_matrix(named_bgc, :palatability)
+        @test named_pal.rows == [:microzoo_1, :microzoo_2, :mesozoo_1]
+        @test named_pal.columns == [:diat_1, :diat_2, :diat_3, :dino_1, :dino_2]
+
         darwin_bgc = Agate.Models.DARWIN.construct(; grid=dummy_grid(Float32))
         @test length(plankton_diameters(darwin_bgc)) == length(plankton_tracers(darwin_bgc))
         @test plankton_diameters(darwin_bgc) == collect(darwin_bgc.plankton_diameters)

--- a/test/test_model_setup_manifest.jl
+++ b/test/test_model_setup_manifest.jl
@@ -39,6 +39,37 @@ end
     @test reconstructed_D ≈ -sinking_tracers.D
 end
 
+@testset "NiPiZD named model setup round trip" begin
+    size_structure = (;
+        phytoplankton=(diat=[2.0, 5.0], dino=[10.0]),
+        zooplankton=(microzoo=[30.0, 60.0], mesozoo=[100.0]),
+    )
+    bgc, setup = Agate.Models.NiPiZD.construct_with_manifest(;
+        size_structure,
+        parameters=(;
+            maximum_growth_rate=(diat_2=1.25 / day,),
+            specificity=(microzoo_1=2.0,),
+        ),
+    )
+
+    path = tempname() * ".json"
+    export_manifest(path, setup)
+    reconstructed = construct_from_manifest(path)
+    test_reconstructed_model(reconstructed, bgc)
+
+    @test Agate.Introspection.plankton_groups(reconstructed) ==
+          Agate.Introspection.plankton_groups(bgc)
+    @test Agate.Introspection.plankton_diameters(reconstructed) ==
+          Agate.Introspection.plankton_diameters(bgc)
+
+    active(model) = Agate.Runtime.active_parameters(model;
+        maximum_growth_rate=(:diat_2,),
+        interactions=(; palatability=((:microzoo_1, :diat_1),)),
+    )
+    @test active(reconstructed).labels == active(bgc).labels
+    @test active(reconstructed).values == active(bgc).values
+end
+
 @testset "DARWIN model setup import" begin
     grid = dummy_grid(Float32)
 

--- a/test/test_models_construct.jl
+++ b/test/test_models_construct.jl
@@ -147,6 +147,81 @@ using Oceananigans.Biogeochemistry:
         )
     end
 
+    @testset "NiPiZD named parameter semantics" begin
+        phyto_diameters = [2.0, 5.0, 10.0]
+        zoo_diameters = [30.0, 60.0, 100.0]
+        named_size_structure = (;
+            phytoplankton=(diat=phyto_diameters[1:2], dino=phyto_diameters[3:3]),
+            zooplankton=(microzoo=zoo_diameters[1:2], mesozoo=zoo_diameters[3:3]),
+        )
+
+        function same_parameter_values(a, b)
+            keys(a) == keys(b) || return false
+            values_match = all(
+                key -> key === :interactions || getproperty(a, key) == getproperty(b, key),
+                keys(a),
+            )
+            interactions_match =
+                a.interactions.palatability == b.interactions.palatability &&
+                a.interactions.assimilation == b.interactions.assimilation
+            return values_match && interactions_match
+        end
+
+        flat = NiPiZD.construct(;
+            phyto_size_structure=phyto_diameters,
+            zoo_size_structure=zoo_diameters,
+            grid=dummy_grid(Float32),
+        )
+        named = NiPiZD.construct(;
+            size_structure=named_size_structure, grid=dummy_grid(Float32)
+        )
+        @test same_parameter_values(named.parameters, flat.parameters)
+
+        growth = copy(named.parameters.maximum_growth_rate)
+        predation = copy(named.parameters.maximum_predation_rate)
+        specificity = copy(named.parameters.specificity)
+        growth[4] = Float32(1.2 / day)
+        predation[2] = Float32(0.7 / day)
+        specificity[1] = 2.0f0
+
+        named_overrides = NiPiZD.construct(;
+            size_structure=named_size_structure,
+            grid=dummy_grid(Float32),
+            parameters=(;
+                maximum_growth_rate=(diat_1=1.2 / day,),
+                maximum_predation_rate=(microzoo_2=0.7 / day,),
+                specificity=(microzoo_1=2.0,),
+            ),
+        )
+        positional_overrides = NiPiZD.construct(;
+            size_structure=named_size_structure,
+            grid=dummy_grid(Float32),
+            parameters=(;
+                maximum_growth_rate=growth,
+                maximum_predation_rate=predation,
+                specificity=specificity,
+            ),
+        )
+        @test same_parameter_values(named_overrides.parameters, positional_overrides.parameters)
+
+        palatability = reshape(Float32.(1:9), 3, 3)
+        assimilation = reshape(Float32.(11:19), 3, 3)
+        explicit_interactions = NiPiZD.construct(;
+            size_structure=named_size_structure,
+            grid=dummy_grid(Float32),
+            palatability_matrix=palatability,
+            assimilation_matrix=assimilation,
+        )
+        @test explicit_interactions.parameters.interactions.palatability == palatability
+        @test explicit_interactions.parameters.interactions.assimilation == assimilation
+
+        @test_throws ArgumentError NiPiZD.construct(;
+            size_structure=named_size_structure,
+            grid=dummy_grid(Float32),
+            palatability_matrix=zeros(Float32, 4, 4),
+        )
+    end
+
     @testset "NiPiZD interaction overrides" begin
         bgc = NiPiZD.construct(; grid=dummy_grid(Float32))
         ints0 = bgc.parameters.interactions

--- a/test/test_models_construct.jl
+++ b/test/test_models_construct.jl
@@ -53,6 +53,88 @@ using Oceananigans.Biogeochemistry:
         @test isfinite(bgc(Val(:Z1), 0, 0, 0, 0, ordered..., PAR))
     end
 
+    @testset "NiPiZD named size structure" begin
+        phyto_diameters = [2.0, 10.0]
+        zoo_diameters = [20.0, 100.0]
+
+        default_groups = NiPiZD.construct(;
+            phyto_size_structure=phyto_diameters,
+            zoo_size_structure=zoo_diameters,
+            grid=dummy_grid(Float32),
+        )
+        named_equivalent = NiPiZD.construct(;
+            size_structure=(;
+                phytoplankton=(P=phyto_diameters,),
+                zooplankton=(Z=zoo_diameters,),
+            ),
+            grid=dummy_grid(Float32),
+        )
+
+        @test required_biogeochemical_tracers(named_equivalent) ==
+            required_biogeochemical_tracers(default_groups)
+        @test named_equivalent.parameters.maximum_growth_rate ==
+            default_groups.parameters.maximum_growth_rate
+        @test named_equivalent.parameters.maximum_predation_rate ==
+            default_groups.parameters.maximum_predation_rate
+        @test named_equivalent.parameters.interactions.palatability ==
+            default_groups.parameters.interactions.palatability
+        @test named_equivalent.parameters.interactions.assimilation ==
+            default_groups.parameters.interactions.assimilation
+
+        named = NiPiZD.construct(;
+            size_structure=(;
+                phytoplankton=(diat=[2.0, 5.0, 10.0], dino=[8.0, 20.0]),
+                zooplankton=(microzoo=[30.0, 60.0], mesozoo=[100.0]),
+            ),
+            grid=dummy_grid(Float32),
+        )
+        tracers = required_biogeochemical_tracers(named)
+        @test tracers[1:2] == (:N, :D)
+        @test length(tracers) == 10
+        @test size(named.parameters.interactions.palatability) == (3, 5)
+        @test size(named.parameters.interactions.assimilation) == (3, 5)
+        @test count(x -> x != 0, named.parameters.maximum_growth_rate) == 5
+        @test count(x -> x != 0, named.parameters.maximum_predation_rate) == 3
+
+        explicit_nothing = NiPiZD.construct(;
+            phyto_size_structure=nothing,
+            zoo_size_structure=nothing,
+            grid=dummy_grid(Float32),
+        )
+        default_model = NiPiZD.construct(; grid=dummy_grid(Float32))
+        @test required_biogeochemical_tracers(explicit_nothing) ==
+            required_biogeochemical_tracers(default_model)
+
+        @test_throws ArgumentError NiPiZD.construct(;
+            size_structure=(;
+                phytoplankton=(diat=[2.0],),
+                zooplankton=(microzoo=[30.0],),
+            ),
+            phyto_size_structure=[2.0],
+        )
+        @test_throws ArgumentError NiPiZD.construct(;
+            size_structure=(; phytoplankton=(diat=[2.0],))
+        )
+        @test_throws ArgumentError NiPiZD.construct(;
+            size_structure=(;
+                phytoplankton=(;),
+                zooplankton=(microzoo=[30.0],),
+            )
+        )
+        @test_throws ArgumentError NiPiZD.construct(;
+            size_structure=(;
+                phytoplankton=(shared=[2.0],),
+                zooplankton=(shared=[30.0],),
+            )
+        )
+        @test_throws ArgumentError NiPiZD.construct(;
+            size_structure=(;
+                phytoplankton=(diat=Float64[],),
+                zooplankton=(microzoo=[30.0],),
+            )
+        )
+    end
+
     @testset "NiPiZD interaction overrides" begin
         bgc = NiPiZD.construct(; grid=dummy_grid(Float32))
         ints0 = bgc.parameters.interactions

--- a/test/test_models_construct.jl
+++ b/test/test_models_construct.jl
@@ -124,27 +124,22 @@ using Oceananigans.Biogeochemistry:
             ),
             phyto_size_structure=[2.0],
         )
-        @test_throws ArgumentError NiPiZD.construct(;
-            size_structure=(; phytoplankton=(diat=[2.0],))
-        )
-        @test_throws ArgumentError NiPiZD.construct(;
-            size_structure=(;
-                phytoplankton=(;),
+        invalid_size_structures = (
+            1,
+            (; phytoplankton=(diat=[2.0],)),
+            (;
+                phytoplankton=(diat=[2.0],),
                 zooplankton=(microzoo=[30.0],),
-            )
+                detritus=(small=[1.0],),
+            ),
+            (; phytoplankton=[2.0], zooplankton=(microzoo=[30.0],)),
+            (; phytoplankton=(;), zooplankton=(microzoo=[30.0],)),
+            (; phytoplankton=(shared=[2.0],), zooplankton=(shared=[30.0],)),
+            (; phytoplankton=(diat=Float64[],), zooplankton=(microzoo=[30.0],)),
         )
-        @test_throws ArgumentError NiPiZD.construct(;
-            size_structure=(;
-                phytoplankton=(shared=[2.0],),
-                zooplankton=(shared=[30.0],),
-            )
-        )
-        @test_throws ArgumentError NiPiZD.construct(;
-            size_structure=(;
-                phytoplankton=(diat=Float64[],),
-                zooplankton=(microzoo=[30.0],),
-            )
-        )
+        for size_structure in invalid_size_structures
+            @test_throws ArgumentError NiPiZD.construct(; size_structure)
+        end
     end
 
     @testset "NiPiZD named parameter semantics" begin

--- a/test/test_models_construct.jl
+++ b/test/test_models_construct.jl
@@ -70,8 +70,10 @@ using Oceananigans.Biogeochemistry:
             grid=dummy_grid(Float32),
         )
 
+        @test required_biogeochemical_tracers(default_groups) ==
+            (:N, :D, :Z1, :Z2, :P1, :P2)
         @test required_biogeochemical_tracers(named_equivalent) ==
-            required_biogeochemical_tracers(default_groups)
+            (:N, :D, :Z_1, :Z_2, :P_1, :P_2)
         @test named_equivalent.parameters.maximum_growth_rate ==
             default_groups.parameters.maximum_growth_rate
         @test named_equivalent.parameters.maximum_predation_rate ==
@@ -89,8 +91,18 @@ using Oceananigans.Biogeochemistry:
             grid=dummy_grid(Float32),
         )
         tracers = required_biogeochemical_tracers(named)
-        @test tracers[1:2] == (:N, :D)
-        @test length(tracers) == 10
+        @test tracers == (
+            :N,
+            :D,
+            :microzoo_1,
+            :microzoo_2,
+            :mesozoo_1,
+            :diat_1,
+            :diat_2,
+            :diat_3,
+            :dino_1,
+            :dino_2,
+        )
         @test size(named.parameters.interactions.palatability) == (3, 5)
         @test size(named.parameters.interactions.assimilation) == (3, 5)
         @test count(x -> x != 0, named.parameters.maximum_growth_rate) == 5


### PR DESCRIPTION
* Adds named phytoplankton and zooplankton groups to `NiPiZD` through `size_structure`, with deterministic `<group>_<index>` tracer names.
* Adds named parameter overrides and named consumer-prey interaction axes for palatability and assimilation.
* Extends `Agate.Runtime.active_parameters`, `parameterized`, and `ode_problem` workflows to named realized tracers.
* Extends model-setup manifest export and replay to preserve named groups and resolved diameters.
* Adds a new example comparing phytoplankton functional types with contrasting light strategies and expands the Runtime API documentation.
