### PR TITLE
replace Pn and Zn with P_n and Z_n

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Agate"
 uuid = "41889b7c-c35c-4f16-abd7-94b299d9fd29"
-version = "0.7.2"
+version = "0.8.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/src/quick_start.md
+++ b/docs/src/quick_start.md
@@ -55,7 +55,7 @@ And finally simulated using Oceananigans.jl
 
 ```@example quickstart
 
-set!(full_model; N=7.0, P1=0.01, Z1=0.01, P2=0.1, Z2=0.01, D=0.01)
+set!(full_model; N=7.0, P_1=0.01, Z_1=0.01, P_2=0.1, Z_2=0.01, D=0.01)
 
 simulation = Simulation(full_model; Δt=240minutes, stop_time=1095days)
 nothing #hide

--- a/examples/1D_column.jl
+++ b/examples/1D_column.jl
@@ -103,7 +103,7 @@ nothing #hide
 
 # ## Initial conditions
 
-set!(full_model; N=7.0, P1=0.01, P2=0.01, Z1=0.05, Z2=0.05, D=0.0) # mmol N / m³
+set!(full_model; N=7.0, P_1=0.01, P_2=0.01, Z_1=0.05, Z_2=0.05, D=0.0) # mmol N / m³
 
 # ## Simulation
 filename = "N2P2ZD_column.jld2"

--- a/examples/export_model_setup.jl
+++ b/examples/export_model_setup.jl
@@ -27,8 +27,10 @@ grid = BoxModelGrid()
 
 bgc, manifest = NiPiZD.construct_with_manifest(;
     grid,
-    phyto_size_structure=(n=3, min_esd=1.0, max_esd=10.0, splitting=:log_splitting),
-    zoo_size_structure=(n=2, min_esd=20.0, max_esd=100.0, splitting=:linear_splitting),
+    size_structure=(;
+        phytoplankton=(P=(n=3, min_esd=1.0, max_esd=10.0, splitting=:log_splitting),),
+        zooplankton=(Z=(n=2, min_esd=20.0, max_esd=100.0, splitting=:linear_splitting),),
+    ),
 )
 
 nothing #hide

--- a/examples/forward_mode_ad_nipizd_sensitivity.jl
+++ b/examples/forward_mode_ad_nipizd_sensitivity.jl
@@ -1,6 +1,6 @@
 # # [Forward-mode AD sensitivity] (@id forward_mode_ad_nipizd_sensitivity_example)
 
-# In this example we use ForwardDiff.jl to compute the sensitivity of phytoplankton 1 (P1) in an N2P2ZD model to P1's maximum growth rate parameter.
+# In this example we use ForwardDiff.jl to compute the sensitivity of phytoplankton 1 (P_1) in an N2P2ZD model to P_1's maximum growth rate parameter.
 
 # ## Loading dependencies
 # The example uses Agate.jl for the ecosystem model, OrdinaryDiffEq.jl for a small standalone ODE solve,
@@ -16,20 +16,20 @@ using Oceananigans.Biogeochemistry: required_biogeochemical_tracers
 using Oceananigans.Units: day
 
 const NiPiZD = Agate.Models.NiPiZD
-const TRACERS = (:N, :D, :Z1, :Z2, :P1, :P2)
+const TRACERS = (:N, :D, :Z_1, :Z_2, :P_1, :P_2)
 nothing #hide
 
 # ## Static model and active parameter
 
-# We construct the model once and let `Agate.Runtime.ode_problem` read P1's
+# We construct the model once and let `Agate.Runtime.ode_problem` read P_1's
 # maximum growth rate from the ODE parameter vector. During ForwardDiff.jl
 # calls only this active entry becomes a dual number; the stored model parameters
 # remain ordinary floating-point values.
 
 const BGC = NiPiZD.construct()
-const ACTIVE = Agate.Runtime.active_parameters(BGC; maximum_growth_rate=(:P1,))
+const ACTIVE = Agate.Runtime.active_parameters(BGC; maximum_growth_rate=(:P_1,))
 
-# Here `theta[1]` is the maximum growth rate of `P1`. The `P2` growth rate and
+# Here `theta[1]` is the maximum growth rate of `P_1`. The `P_2` growth rate and
 # omitted zooplankton entries are held fixed at the model defaults.
 
 # ## Standalone ODE problem
@@ -61,16 +61,16 @@ function solve_nipizd(theta; saveat=range(0.0, 365day; length=366))
 end
 nothing #hide
 
-# We expose the `P1` trajectory (e.g. biomass values over time) as a vector-valued function of one parameter.
+# We expose the `P_1` trajectory (e.g. biomass values over time) as a vector-valued function of one parameter.
 # This is the function that ForwardDiff.jl differentiates.
 
-function p1_trajectory(theta; saveat=range(0.0, 365day; length=366))
+function p_1_trajectory(theta; saveat=range(0.0, 365day; length=366))
     sol = solve_nipizd(theta; saveat=saveat)
     values = reduce(hcat, sol.u)
     return vec(values[5, :])
 end
 
-function p1_solution(mu; saveat=range(0.0, 365day; length=366))
+function p_1_solution(mu; saveat=range(0.0, 365day; length=366))
     sol = solve_nipizd([mu]; saveat=saveat)
     values = reduce(hcat, sol.u)
     return vec(values[5, :])
@@ -79,12 +79,12 @@ nothing #hide
 
 # ## ForwardDiff.jl and finite differences
 
-# We compute the time-dependent sensitivity of `P1` to its own maximum growth rate.
+# We compute the time-dependent sensitivity of `P_1` to its own maximum growth rate.
 # A central finite difference provides a simple independent check.
 
-function finite_difference_p1_trajectory(mu0, delta; saveat)
-    plus = p1_trajectory([mu0 + delta]; saveat=saveat)
-    minus = p1_trajectory([mu0 - delta]; saveat=saveat)
+function finite_difference_p_1_trajectory(mu0, delta; saveat)
+    plus = p_1_trajectory([mu0 + delta]; saveat=saveat)
+    minus = p_1_trajectory([mu0 - delta]; saveat=saveat)
     return (plus .- minus) ./ (2delta)
 end
 
@@ -92,13 +92,13 @@ saveat = collect(range(0.0, 365day; length=366))
 mu0 = 0.7 / day
 delta = mu0 * 1e-6
 
-baseline = p1_solution(mu0; saveat=saveat)
-J = ForwardDiff.jacobian(theta -> p1_trajectory(theta; saveat=saveat), [mu0])
+baseline = p_1_solution(mu0; saveat=saveat)
+J = ForwardDiff.jacobian(theta -> p_1_trajectory(theta; saveat=saveat), [mu0])
 forwarddiff_sensitivity = J[:, 1]
-finite_difference_sensitivity = finite_difference_p1_trajectory(mu0, delta; saveat=saveat)
+finite_difference_sensitivity = finite_difference_p_1_trajectory(mu0, delta; saveat=saveat)
 
-@printf("Final dP1/dmu, ForwardDiff:       %.8e\n", forwarddiff_sensitivity[end])
-@printf("Final dP1/dmu, finite difference: %.8e\n", finite_difference_sensitivity[end])
+@printf("Final dP_1/dmu, ForwardDiff:       %.8e\n", forwarddiff_sensitivity[end])
+@printf("Final dP_1/dmu, finite difference: %.8e\n", finite_difference_sensitivity[end])
 @printf(
     "Maximum absolute sensitivity difference: %.8e\n",
     maximum(abs.(forwarddiff_sensitivity .- finite_difference_sensitivity)),
@@ -106,31 +106,31 @@ finite_difference_sensitivity = finite_difference_p1_trajectory(mu0, delta; save
 
 # ## Plotting
 
-# The top panel shows P1 biomass over time.
+# The top panel shows P_1 biomass over time.
 # The bottom panel compares the ForwardDiff.jl sensitivity with the central finite difference estimate.
 
 time_days = saveat ./ day
 fig = Figure(; size=(900, 620), fontsize=14)
 
 ax1 = Axis(
-    fig[1, 1]; xlabel="time (days)", ylabel="P1 concentration", title="NiPiZD P1 biomass"
+    fig[1, 1]; xlabel="time (days)", ylabel="P_1 concentration", title="NiPiZD P_1 biomass"
 )
-lines!(ax1, time_days, baseline; label="P1", linewidth=3)
+lines!(ax1, time_days, baseline; label="P_1", linewidth=3)
 axislegend(ax1; position=:rb)
 
 ax2 = Axis(
     fig[2, 1];
     xlabel="time (days)",
-    ylabel="sensitivity to P1 growth rate",
+    ylabel="sensitivity to P_1 growth rate",
     title="ForwardDiff sensitivity vs finite-difference sensitivity",
 )
-lines!(ax2, time_days, forwarddiff_sensitivity; label="dP1/dμ₁, ForwardDiff", linewidth=3)
+lines!(ax2, time_days, forwarddiff_sensitivity; label="dP_1/dμ₁, ForwardDiff", linewidth=3)
 lines!(
     ax2,
     time_days,
     finite_difference_sensitivity;
     linestyle=:dash,
-    label="dP1/dμ₁, finite difference",
+    label="dP_1/dμ₁, finite difference",
     linewidth=3,
 )
 axislegend(ax2; position=:rb)

--- a/examples/predator_prey_palatability.jl
+++ b/examples/predator_prey_palatability.jl
@@ -42,7 +42,7 @@ nothing #hide
 # filled from the model defaults.
 
 vopt_bgc = Agate.Models.NiPiZD.construct(;
-    parameters=(; optimum_predator_prey_ratio=(Z1=5.0, Z2=5.0))
+    parameters=(; optimum_predator_prey_ratio=(Z_1=5.0, Z_2=5.0))
 )
 vopt_pal = interaction_matrix(vopt_bgc, :palatability)
 nothing #hide
@@ -119,7 +119,7 @@ function run_box_model(bgc, filename)
     bgc_model = Biogeochemistry(bgc; light_attenuation)
     full_model = BoxModel(; biogeochemistry=bgc_model)
 
-    set!(full_model; N=7.0, P1=0.01, Z1=0.01, P2=0.1, Z2=0.01, D=0.01)
+    set!(full_model; N=7.0, P_1=0.01, Z_1=0.01, P_2=0.1, Z_2=0.01, D=0.01)
 
     simulation = Simulation(full_model; Δt=240minutes, stop_time=1095days)
 

--- a/examples/reverse_mode_ad_nipizd_sensitivity.jl
+++ b/examples/reverse_mode_ad_nipizd_sensitivity.jl
@@ -44,11 +44,11 @@ const PHYTOPLANKTON = PLANKTON_GROUPS.P
 const PHYTOPLANKTON_INDICES = tracer_index.(PHYTOPLANKTON)
 
 const ACTIVE = Agate.Runtime.active_parameters(BGC;
-    maximum_growth_rate = (:P1, :P2),
+    maximum_growth_rate = (:P_1, :P_2),
     detritus_remineralization = true,
     interactions = (;
-        palatability = ((:Z1, :P1), (:Z1, :P2), (:Z2, :P1)),
-        assimilation = ((:Z1, :P1),),
+        palatability = ((:Z_1, :P_1), (:Z_1, :P_2), (:Z_2, :P_1)),
+        assimilation = ((:Z_1, :P_1),),
     ),
 )
 const PARAMETER_LABELS = ACTIVE.labels
@@ -61,8 +61,8 @@ const PAR = CyclicalPAR(-10)
 nothing #hide
 
 const INITIAL_CONCENTRATIONS = (; N = 7.0, D = 0.01,
-                                 Z1 = 0.01, Z2 = 0.01,
-                                 P1 = 0.01, P2 = 0.1)
+                                 Z_1 = 0.01, Z_2 = 0.01,
+                                 P_1 = 0.01, P_2 = 0.1)
 
 function initial_conditions(::Type{T}) where {T}
     return T[getproperty(INITIAL_CONCENTRATIONS, tracer) for tracer in TRACER_NAMES]

--- a/examples/size_structure.jl
+++ b/examples/size_structure.jl
@@ -26,19 +26,19 @@ nothing #hide
 # The plankton size structure is configured separately for phytoplankton and
 # zooplankton. Here, phytoplankton are split into three classes spanning 1 to
 # 10 μm equivalent spherical diameter (ESD), using logarithmic spacing.
-
 phyto_size_structure = (n=3, min_esd=1, max_esd=10, splitting=:log_splitting)
 nothing #hide
 
 # Alternatively, an explicit array can be used.
 # This zooplankton size structure also defines three classes, specifying the ESD of each class directly.
-
 zoo_size_structure = [10.0, 32.0, 100.0]
 
-# The model is constructed following the default model setup but with the custom size structures. 
-# This creates three phytoplankton tracers and three zooplankton tracers.
+size_structure = (;
+    phytoplankton=(P=phyto_size_structure,),
+    zooplankton=(Z=zoo_size_structure,),
+)
 
-bgc = Agate.Models.NiPiZD.construct(; phyto_size_structure, zoo_size_structure)
+bgc = Agate.Models.NiPiZD.construct(; size_structure)
 nothing #hide
 
 # We can inspect the tracer names required by the model.

--- a/examples/size_structure.jl
+++ b/examples/size_structure.jl
@@ -67,7 +67,7 @@ nothing #hide
 
 # ## Initial conditions
 
-set!(full_model; N=8.0, P1=0.01, P2=0.05, P3=0.1, Z1=0.01, Z2=0.01, Z3=0.01, D=0.01)
+set!(full_model; N=8.0, P_1=0.01, P_2=0.05, P_3=0.1, Z_1=0.01, Z_2=0.01, Z_3=0.01, D=0.01)
 
 # ## Simulation
 

--- a/paper/GPU/column_DARWIN_agate.jl
+++ b/paper/GPU/column_DARWIN_agate.jl
@@ -76,10 +76,10 @@ set!(
     PON=0.0,
     DOP=0.0,
     POP=0.0,
-    P1=0.01,
-    P2=0.01,
-    Z1=0.05,
-    Z2=0.05,
+    P_1=0.01,
+    P_2=0.01,
+    Z_1=0.05,
+    Z_2=0.05,
 )
 
 simulation = Simulation(model; Δt=3minutes, stop_time=365days)

--- a/paper/GPU/column_N2P2ZD_agate.jl
+++ b/paper/GPU/column_N2P2ZD_agate.jl
@@ -63,7 +63,7 @@ model = NonhydrostaticModel(;
     auxiliary_fields=(; T, S),
 )
 
-set!(model; P1=0.01, P2=0.01, Z1=0.05, Z2=0.05, N=7.0, D=1)
+set!(model; P_1=0.01, P_2=0.01, Z_1=0.05, Z_2=0.05, N=7.0, D=1)
 
 simulation = Simulation(model; Δt=3minutes, stop_time=365days)
 

--- a/src/Configuration/community.jl
+++ b/src/Configuration/community.jl
@@ -320,9 +320,6 @@ function parse_community(
         end
     end
 
-    length(unique(plankton_symbols)) == length(plankton_symbols) ||
-        throw(ArgumentError("plankton tracer names must be unique"))
-
     biogeochem_symbols = Set(keys(biogeochem_dynamics))
     conflicting_symbols = [symbol for symbol in plankton_symbols if symbol in biogeochem_symbols]
     isempty(conflicting_symbols) || throw(

--- a/src/Configuration/community.jl
+++ b/src/Configuration/community.jl
@@ -150,12 +150,6 @@ normalize_diameters(spec::DiameterRangeSpecification) = (; n=spec.n, specificati
 
 normalize_diameters(spec) = throw(ArgumentError("invalid `diameters` specification"))
 
-_tracer_names_issue(names, group, n) =
-    !(names isa Tuple || names isa AbstractVector) ? "group $group: `tracer_names` must be a Tuple or AbstractVector" :
-    !all(name -> name isa Symbol, names) ? "group $group: `tracer_names` entries must be Symbols" :
-    !isnothing(n) && length(names) != n ? "group $group: `tracer_names` must have length $n" :
-    nothing
-
 """Validate `plankton_dynamics` and `community` inputs.
 
 Throws a single `ArgumentError` listing all issues.
@@ -236,13 +230,6 @@ function validate_community_inputs(plankton_dynamics, community)
             ok = pft isa PFTSpecification || pft isa NamedTuple
             ok || push!(issues, "group $(k): `pft` must be PFTSpecification or NamedTuple")
         end
-
-        if hasproperty(spec, :tracer_names)
-            names = getproperty(spec, :tracer_names)
-            n = hasproperty(spec, :n) ? getproperty(spec, :n) : nothing
-            issue = _tracer_names_issue(names, k, n)
-            isnothing(issue) || push!(issues, issue)
-        end
     end
 
     if !isempty(issues)
@@ -322,14 +309,7 @@ function parse_community(
         pft_raw = getproperty(spec, :pft)
         pft = pft_raw isa PFTSpecification ? pft_raw : PFTSpecification(pft_raw)
 
-        class_symbols = if hasproperty(spec, :tracer_names)
-            names = getproperty(spec, :tracer_names)
-            issue = _tracer_names_issue(names, g, n)
-            isnothing(issue) || throw(ArgumentError(issue))
-            Symbol[names...]
-        else
-            Symbol[Symbol(string(g), "_", i) for i in 1:n]
-        end
+        class_symbols = Symbol[Symbol(string(g), "_", i) for i in 1:n]
 
         for i in 1:n
             push!(plankton_symbols, class_symbols[i])

--- a/src/Configuration/community.jl
+++ b/src/Configuration/community.jl
@@ -93,7 +93,7 @@ Fields
 - `n_total`: total number of plankton classes.
 - `diameters`: flattened diameter vector in global plankton order.
 - `pfts`: per-class PFT specifications.
-- `plankton_symbols`: flattened class symbols such as `:P1`, `:P2`, or `:diat_1`.
+- `plankton_symbols`: flattened class symbols such as `:P_1`, `:P_2`, or `:diat_1`.
 - `group_symbols`: group symbol for each flattened class.
 - `group_local_index`: within-group class index for each flattened class.
 - `group_indices`: mapping from group symbol to flattened class indices.
@@ -328,7 +328,7 @@ function parse_community(
             isnothing(issue) || throw(ArgumentError(issue))
             Symbol[names...]
         else
-            Symbol[Symbol(string(g), i) for i in 1:n]
+            Symbol[Symbol(string(g), "_", i) for i in 1:n]
         end
 
         for i in 1:n

--- a/src/Diagnostics/box_model.jl
+++ b/src/Diagnostics/box_model.jl
@@ -4,8 +4,8 @@
 Compute a weighted sum of tracer values in `box_model` at the given grid `location`.
 
 `terms` may be either:
-- an `AbstractVector` of pairs `tracer_symbol => weight`, e.g. `[:N => 1, :P1 => 1]`, or
-- a `NamedTuple` of weights, e.g. `(N=1, P1=1)`.
+- an `AbstractVector` of pairs `tracer_symbol => weight`, e.g. `[:N => 1, :P_1 => 1]`, or
+- a `NamedTuple` of weights, e.g. `(N=1, P_1=1)`.
 
 The function assumes tracer fields are accessible as `box_model.fields.<tracer>` and store
 their data in `.data`.

--- a/src/Library/predation.jl
+++ b/src/Library/predation.jl
@@ -59,11 +59,11 @@ end
 @inline function (f::IdealizedPredationLoss)(P, Z)
     gmax = f.maximum_grazing_rate
     K = f.half_saturation
-    P2 = P * P
-    if K == zero(K) && P2 == zero(P2)
+    P_squared = P * P
+    if K == zero(K) && P_squared == zero(P_squared)
         return zero(P * Z)
     end
-    return gmax * (P2 / (K * K + P2)) * Z
+    return gmax * (P_squared / (K * K + P_squared)) * Z
 end
 
 """

--- a/src/Models/NiPiZD/factory.jl
+++ b/src/Models/NiPiZD/factory.jl
@@ -18,6 +18,11 @@ using ...Tendencies:
 """Factory for the size-structured NiPiZD model."""
 struct NiPiZDFactory <: AbstractBGCFactory end
 
+const DEFAULT_SIZE_STRUCTURE = (
+    phytoplankton=(P=(n=2, min_esd=2, max_esd=10, splitting=:log_splitting),),
+    zooplankton=(Z=(n=2, min_esd=20, max_esd=100, splitting=:linear_splitting),),
+)
+
 const NIPIZD_TENDENCIES = TendencyConfig(;
     growth=:smith,
     organic_cycling=:simple_detritus,
@@ -58,13 +63,8 @@ function default_community(::NiPiZDFactory)
     # Structural defaults only (sizes/diameters). No parameter defaults.
     empty_pft = PFTSpecification()
     return (
-        Z=(;
-            diameters=(n=2, min_esd=20, max_esd=100, splitting=:linear_splitting),
-            pft=empty_pft,
-        ),
-        P=(;
-            diameters=(n=2, min_esd=2, max_esd=10, splitting=:log_splitting), pft=empty_pft
-        ),
+        Z=(; diameters=DEFAULT_SIZE_STRUCTURE.zooplankton.Z, pft=empty_pft),
+        P=(; diameters=DEFAULT_SIZE_STRUCTURE.phytoplankton.P, pft=empty_pft),
     )
 end
 

--- a/src/Models/NiPiZD/interface.jl
+++ b/src/Models/NiPiZD/interface.jl
@@ -2,18 +2,11 @@ using OceanBioME: BoxModelGrid
 
 import ...Configuration
 import ...Construction
-import ...Factories
-
 using ...Manifests: default_model_manifest
 
 export construct, construct_with_manifest
 
-const DEFAULT_PHYTO_SIZE_STRUCTURE =
-    (n=2, min_esd=2, max_esd=10, splitting=:log_splitting)
-const DEFAULT_ZOO_SIZE_STRUCTURE =
-    (n=2, min_esd=20, max_esd=100, splitting=:linear_splitting)
-
-function _named_size_structure(size_structure)
+function _validated_size_structure(size_structure)
     size_structure isa NamedTuple ||
         throw(ArgumentError("size_structure must be a NamedTuple"))
 
@@ -50,17 +43,17 @@ function _named_size_structure(size_structure)
     return (; phytoplankton, zooplankton, producer_groups, consumer_groups)
 end
 
-function _named_community_inputs(size_structure)
-    named = _named_size_structure(size_structure)
-    group_order = (named.consumer_groups..., named.producer_groups...)
+function _community_inputs(size_structure)
+    structure = _validated_size_structure(size_structure)
+    group_order = (structure.consumer_groups..., structure.producer_groups...)
     empty_pft = Configuration.PFTSpecification()
 
     community_base_values = ntuple(length(group_order)) do i
         group = group_order[i]
-        diameters = if group in named.consumer_groups
-            getproperty(named.zooplankton, group)
+        diameters = if group in structure.consumer_groups
+            getproperty(structure.zooplankton, group)
         else
-            getproperty(named.phytoplankton, group)
+            getproperty(structure.phytoplankton, group)
         end
         return (; diameters, pft=empty_pft)
     end
@@ -69,21 +62,19 @@ function _named_community_inputs(size_structure)
 
     dynamics_values = ntuple(length(group_order)) do i
         group = group_order[i]
-        return group in named.consumer_groups ? zooplankton_nipizd : phytoplankton_nipizd
+        return group in structure.consumer_groups ? zooplankton_nipizd : phytoplankton_nipizd
     end
     plankton_dynamics = NamedTuple{group_order}(dynamics_values)
-    interaction_roles = (consumers=named.consumer_groups, prey=named.producer_groups)
+    interaction_roles = (consumers=structure.consumer_groups, prey=structure.producer_groups)
 
     group_roles = (;
-        phytoplankton=named.producer_groups, zooplankton=named.consumer_groups
+        phytoplankton=structure.producer_groups, zooplankton=structure.consumer_groups
     )
     return (; community, plankton_dynamics, interaction_roles, group_roles)
 end
 
 function _construction_inputs(;
-    size_structure=nothing,
-    phyto_size_structure=nothing,
-    zoo_size_structure=nothing,
+    size_structure=DEFAULT_SIZE_STRUCTURE,
     parameters::NamedTuple=(;),
     palatability_matrix=nothing,
     assimilation_matrix=nothing,
@@ -94,30 +85,7 @@ function _construction_inputs(;
     open_bottom::Bool=true,
 )
     factory = NiPiZDFactory()
-
-    community_inputs = if isnothing(size_structure)
-        phyto =
-            isnothing(phyto_size_structure) ? DEFAULT_PHYTO_SIZE_STRUCTURE : phyto_size_structure
-        zoo =
-            isnothing(zoo_size_structure) ? DEFAULT_ZOO_SIZE_STRUCTURE : zoo_size_structure
-        base = Factories.default_community(factory)
-        community = Configuration.build_plankton_community(
-            base; diameters=(Z=zoo, P=phyto)
-        )
-        (;
-            community,
-            plankton_dynamics=Factories.default_plankton_dynamics(factory),
-            interaction_roles=(consumers=(:Z,), prey=(:P,)),
-            group_roles=nothing,
-        )
-    else
-        (isnothing(phyto_size_structure) && isnothing(zoo_size_structure)) || throw(
-            ArgumentError(
-                "size_structure cannot be combined with phyto_size_structure or zoo_size_structure",
-            ),
-        )
-        _named_community_inputs(size_structure)
-    end
+    community_inputs = _community_inputs(size_structure)
 
     pairs = Pair{Symbol,Any}[]
     palatability_matrix !== nothing &&
@@ -151,8 +119,8 @@ end
 
 Construct a size-structured NiPiZD ecosystem model.
 
-The NiPiZD model contains phytoplankton and zooplankton roles. The default groups are
-`P` and `Z`; `size_structure` may define multiple named groups within either role.
+The NiPiZD model contains phytoplankton and zooplankton roles. `size_structure` defines
+the groups within each role; the defaults are `P` and `Z`.
 
 In addition to plankton, the default NiPiZD factory includes idealized nutrient (`N`) and
 detritus (`D`) cycling. The returned biogeochemistry instance includes a photosynthetically
@@ -165,21 +133,16 @@ may override interaction matrices explicitly with `palatability_matrix` and/or
 
 Each group size structure may be a NamedTuple range, for example
 `(n=3, min_esd=1, max_esd=10, splitting=:log_splitting)`, or an explicit
-diameter vector such as `[1.0, 3.2, 10.0]`. Named groups are supplied as
-`size_structure=(phytoplankton=(...), zooplankton=(...))`.
-Classes in named groups use `<group>_<index>` tracer names, such as `diat_1`.
-The default `P` and `Z` groups use `P_1`, `P_2`, `Z_1`, `Z_2`, and so on.
+diameter vector such as `[1.0, 3.2, 10.0]`. Groups are supplied as
+`size_structure=(phytoplankton=(...), zooplankton=(...))` and classes use
+`<group>_<index>` tracer names, such as `P_1` or `diat_1`.
 
 Keywords
 --------
-- `size_structure=nothing`: optional named phytoplankton and zooplankton groups, supplied as a
-  NamedTuple with `phytoplankton` and `zooplankton` fields. When supplied, this defines the
-  plankton community.
-- `phyto_size_structure=nothing`: phytoplankton size structure for the default `P` group. When
-  omitted, uses `(n=2, min_esd=2, max_esd=10, splitting=:log_splitting)`.
-- `zoo_size_structure=nothing`: zooplankton size structure for the default `Z` group. When
-  omitted, uses `(n=2, min_esd=20, max_esd=100, splitting=:linear_splitting)`.
-- `parameters=(;)`: parameter overrides (validated against the NiPiZD parameter set). Vector parameters may be supplied positionally, as partial NamedTuple overrides keyed by realized plankton tracer name (for example `diat_1` or `microzoo_1` for named groups), or as allometric definitions for diameter-indexed plankton vectors.
+- `size_structure`: phytoplankton and zooplankton groups, supplied as a NamedTuple with
+  `phytoplankton` and `zooplankton` fields. Defaults to `P` and `Z` groups with two size classes
+  each.
+- `parameters=(;)`: parameter overrides (validated against the NiPiZD parameter set). Vector parameters may be supplied positionally, as partial NamedTuple overrides keyed by realized plankton tracer name (for example `P_1`, `diat_1`, or `microzoo_1`), or as allometric definitions for diameter-indexed plankton vectors.
 - `palatability_matrix=nothing`: optional palatability matrix override. Must be an explicit rectangular matrix with rows ordered by realized zooplankton classes and columns ordered by realized phytoplankton classes.
 - `assimilation_matrix=nothing`: optional assimilation matrix override with the same consumer-by-prey class ordering as `palatability_matrix`.
 - `grid=BoxModelGrid()`: grid used for architecture inference and default scalar-type selection
@@ -224,7 +187,7 @@ end
     construct_with_manifest(; kw...) -> bgc, manifest
 
 Construct a model instance and return it with a JSON-compatible model setup manifest.
-Named groups are recorded in role/group order with their resolved class diameters.
+Groups are recorded in role/group order with their resolved class diameters.
 """
 function construct_with_manifest(; kwargs...)
     inputs = _construction_inputs(; kwargs...)

--- a/src/Models/NiPiZD/interface.jl
+++ b/src/Models/NiPiZD/interface.jl
@@ -65,14 +65,7 @@ function _named_community_inputs(size_structure)
         return (; diameters, pft=empty_pft)
     end
     community_base = NamedTuple{group_order}(community_base_values)
-    sized_community = Configuration.build_plankton_community(community_base)
-    community_values = ntuple(length(group_order)) do i
-        group = group_order[i]
-        spec = getproperty(sized_community, group)
-        tracer_names = ntuple(j -> Symbol(string(group), "_", j), spec.n)
-        return (; spec..., tracer_names)
-    end
-    community = NamedTuple{group_order}(community_values)
+    community = Configuration.build_plankton_community(community_base)
 
     dynamics_values = ntuple(length(group_order)) do i
         group = group_order[i]
@@ -175,7 +168,7 @@ Each group size structure may be a NamedTuple range, for example
 diameter vector such as `[1.0, 3.2, 10.0]`. Named groups are supplied as
 `size_structure=(phytoplankton=(...), zooplankton=(...))`.
 Classes in named groups use `<group>_<index>` tracer names, such as `diat_1`.
-The default `P` and `Z` groups use `P1`, `P2`, `Z1`, `Z2`, and so on.
+The default `P` and `Z` groups use `P_1`, `P_2`, `Z_1`, `Z_2`, and so on.
 
 Keywords
 --------
@@ -192,7 +185,7 @@ Keywords
 - `grid=BoxModelGrid()`: grid used for architecture inference and default scalar-type selection
 - `scalar_type=nothing`: explicit runtime scalar type. When omitted, construction uses `eltype(grid)` or `Float64` if no grid is supplied
 - `arch=nothing`: override the architecture (usually inferred from `grid`)
-- `sinking_tracers=nothing`: sinking speed overrides, e.g. `(D = 2/day, P1 = 0.1/day, ...)`
+- `sinking_tracers=nothing`: sinking speed overrides, e.g. `(D = 2/day, P_1 = 0.1/day, ...)`
 - `open_bottom=true`: whether sinking tracers leave the domain
 
 Returns

--- a/src/Runtime/active_parameters.jl
+++ b/src/Runtime/active_parameters.jl
@@ -121,10 +121,10 @@ matrix parameters with row-column tracer pairs.
 ```julia
 active = active_parameters(
     bgc;
-    maximum_growth_rate = (:P1, :P2),
+    maximum_growth_rate = (:P_1, :P_2),
     detritus_remineralization = true,
     interactions = (;
-        palatability = ((:Z1, :P1), (:Z1, :P2)),
+        palatability = ((:Z_1, :P_1), (:Z_1, :P_2)),
     ),
 )
 
@@ -196,8 +196,8 @@ function active_parameter_entry!(labels, values, bgc, path::Tuple, value, select
     end
 
     throw(ArgumentError(
-        "Active parameter tuple selections must contain tracer symbols, such as (:P1, :P2), " *
-        "or row-column tracer pairs, such as ((:Z1, :P1), (:Z1, :P2))."
+        "Active parameter tuple selections must contain tracer symbols, such as (:P_1, :P_2), " *
+        "or row-column tracer pairs, such as ((:Z_1, :P_1), (:Z_1, :P_2))."
     ))
 end
 

--- a/test/test_active_parameters.jl
+++ b/test/test_active_parameters.jl
@@ -17,10 +17,10 @@ const ActiveParameterNiPiZD = Agate.Models.NiPiZD
 @testset "parameterized BGC" begin
     mu0 = 0.7 / day
     base_bgc = ActiveParameterNiPiZD.construct(;
-        parameters=(; maximum_growth_rate=(P1=mu0, P2=mu0)),
+        parameters=(; maximum_growth_rate=(P_1=mu0, P_2=mu0)),
     )
 
-    active_growth = Agate.Runtime.active_parameters(base_bgc; maximum_growth_rate = (:P1,))
+    active_growth = Agate.Runtime.active_parameters(base_bgc; maximum_growth_rate = (:P_1,))
     p = [mu0]
     bgc_p = Agate.Runtime.parameterized(
         base_bgc,
@@ -29,15 +29,15 @@ const ActiveParameterNiPiZD = Agate.Models.NiPiZD
     )
 
     args = (0, 0, 0, 0, 7.0, 1.0, 0.05, 0.05, 0.01, 0.01, 100.0)
-    base_tendency = base_bgc(Val(:P1), args...)
-    active_tendency = bgc_p(Val(:P1), args...)
+    base_tendency = base_bgc(Val(:P_1), args...)
+    active_tendency = bgc_p(Val(:P_1), args...)
 
     @test active_tendency ≈ base_tendency
     @test bgc_p.parameters.maximum_growth_rate[3] == p[1]
     @test bgc_p.parameters.maximum_growth_rate[4] == base_bgc.parameters.maximum_growth_rate[4]
 
     active_scalar = Agate.Runtime.active_parameters(base_bgc;
-        maximum_growth_rate = (:P1,),
+        maximum_growth_rate = (:P_1,),
         detritus_remineralization = true,
     )
     p_scalar = [mu0, 2base_bgc.parameters.detritus_remineralization]
@@ -53,10 +53,10 @@ const ActiveParameterNiPiZD = Agate.Models.NiPiZD
 
 
     active_matrix = Agate.Runtime.active_parameters(base_bgc;
-        maximum_growth_rate = (:P1,),
+        maximum_growth_rate = (:P_1,),
         interactions = (;
-            palatability = ((:Z1, :P1),),
-            assimilation = ((:Z1, :P1),),
+            palatability = ((:Z_1, :P_1),),
+            assimilation = ((:Z_1, :P_1),),
         ),
     )
     p_matrix = [mu0, 3base_bgc.parameters.interactions.palatability[1, 1], 0.8]
@@ -71,7 +71,7 @@ const ActiveParameterNiPiZD = Agate.Models.NiPiZD
     @test bgc_matrix.parameters.interactions.assimilation[1, 1] == p_matrix[3]
     @test bgc_matrix.parameters.interactions.palatability[1, 2] == base_bgc.parameters.interactions.palatability[1, 2]
 
-    matrix_tendency = bgc_matrix(Val(:P1), args...)
+    matrix_tendency = bgc_matrix(Val(:P_1), args...)
     @test matrix_tendency != base_tendency
 
     p_fast = [2mu0]
@@ -80,16 +80,16 @@ const ActiveParameterNiPiZD = Agate.Models.NiPiZD
         p_fast;
         active_parameters=active_growth,
     )
-    fast_tendency = fast_bgc(Val(:P1), args...)
+    fast_tendency = fast_bgc(Val(:P_1), args...)
 
     @test fast_tendency != base_tendency
     @test fast_bgc.bgc === base_bgc
     @test required_biogeochemical_tracers(fast_bgc) == required_biogeochemical_tracers(base_bgc)
     @test required_biogeochemical_auxiliary_fields(fast_bgc) == required_biogeochemical_auxiliary_fields(base_bgc)
-    @test biogeochemical_drift_velocity(fast_bgc, Val(:P1)) == biogeochemical_drift_velocity(base_bgc, Val(:P1))
+    @test biogeochemical_drift_velocity(fast_bgc, Val(:P_1)) == biogeochemical_drift_velocity(base_bgc, Val(:P_1))
 
     adapted_bgc = Adapt.adapt(identity, fast_bgc)
-    @test adapted_bgc(Val(:P1), args...) ≈ fast_tendency
+    @test adapted_bgc(Val(:P_1), args...) ≈ fast_tendency
 end
 
 @testset "parameterized BGC OceanBioME compatibility" begin
@@ -97,10 +97,10 @@ end
     mu0 = 0.7 / day
     base_bgc = ActiveParameterNiPiZD.construct(;
         grid,
-        parameters=(; maximum_growth_rate=(P1=mu0, P2=mu0)),
+        parameters=(; maximum_growth_rate=(P_1=mu0, P_2=mu0)),
     )
 
-    active_growth = Agate.Runtime.active_parameters(base_bgc; maximum_growth_rate = (:P1,))
+    active_growth = Agate.Runtime.active_parameters(base_bgc; maximum_growth_rate = (:P_1,))
     p = copy(active_growth.values)
     bgc_p = Agate.Runtime.parameterized(base_bgc, p; active_parameters=active_growth)
 
@@ -118,11 +118,11 @@ end
 @testset "ODE problem active parameters" begin
     mu0 = 0.7 / day
     base_bgc = ActiveParameterNiPiZD.construct(;
-        parameters=(; maximum_growth_rate=(P1=mu0, P2=mu0)),
+        parameters=(; maximum_growth_rate=(P_1=mu0, P_2=mu0)),
     )
 
     u0 = [7.0, 1.0, 0.05, 0.05, 0.01, 0.01]
-    active_growth = Agate.Runtime.active_parameters(base_bgc; maximum_growth_rate = (:P1,))
+    active_growth = Agate.Runtime.active_parameters(base_bgc; maximum_growth_rate = (:P_1,))
     p = [mu0]
 
     problem = Agate.Runtime.ode_problem(
@@ -141,7 +141,7 @@ end
         base_bgc,
         p;
         active_parameters=active_growth,
-    )(Val(:P1), 0, 0, 0, 0.0, u0..., 100.0)
+    )(Val(:P_1), 0, 0, 0, 0.0, u0..., 100.0)
 
     @test du[5] ≈ expected
 
@@ -153,7 +153,7 @@ end
 
     p_scalar = [mu0, 2base_bgc.parameters.detritus_remineralization]
     active_scalar = Agate.Runtime.active_parameters(base_bgc;
-        maximum_growth_rate = (:P1,),
+        maximum_growth_rate = (:P_1,),
         detritus_remineralization = true,
     )
     problem_scalar = Agate.Runtime.ode_problem(
@@ -177,8 +177,8 @@ end
     @test du_scalar[1] ≈ expected_scalar
 
     active_matrix = Agate.Runtime.active_parameters(base_bgc;
-        maximum_growth_rate = (:P1,),
-        interactions = (; palatability = ((:Z1, :P1),)),
+        maximum_growth_rate = (:P_1,),
+        interactions = (; palatability = ((:Z_1, :P_1),)),
     )
     p_matrix = [mu0, 3base_bgc.parameters.interactions.palatability[1, 1]]
     problem_matrix = Agate.Runtime.ode_problem(
@@ -197,7 +197,7 @@ end
         base_bgc,
         p_matrix;
         active_parameters=active_matrix,
-    )(Val(:P1), 0, 0, 0, 0.0, u0..., 100.0)
+    )(Val(:P_1), 0, 0, 0, 0.0, u0..., 100.0)
 
     @test du_matrix[5] ≈ expected_matrix
     @test du_matrix[5] != du[5]
@@ -219,9 +219,9 @@ end
     base_bgc = ActiveParameterNiPiZD.construct()
 
     palatability_selectors = (
-        () -> Agate.Runtime.active_parameters(base_bgc; specificity = (:Z1,)),
-        () -> Agate.Runtime.active_parameters(base_bgc; protection = (:P1,)),
-        () -> Agate.Runtime.active_parameters(base_bgc; optimum_predator_prey_ratio = (:Z1,)),
+        () -> Agate.Runtime.active_parameters(base_bgc; specificity = (:Z_1,)),
+        () -> Agate.Runtime.active_parameters(base_bgc; protection = (:P_1,)),
+        () -> Agate.Runtime.active_parameters(base_bgc; optimum_predator_prey_ratio = (:Z_1,)),
     )
 
     for selector in palatability_selectors
@@ -229,12 +229,12 @@ end
     end
 
     assimilation_message = argument_error_message(() ->
-        Agate.Runtime.active_parameters(base_bgc; assimilation_efficiency = (:Z1,))
+        Agate.Runtime.active_parameters(base_bgc; assimilation_efficiency = (:Z_1,))
     )
     @test occursin(":interactions.assimilation", assimilation_message)
 
     @test_throws ArgumentError Agate.Runtime.active_parameters(base_bgc; palatability_matrix = true)
-    @test_throws ArgumentError Agate.Runtime.active_parameters(base_bgc; maximum_growth_rate = ((:P1, :P2, :extra),))
+    @test_throws ArgumentError Agate.Runtime.active_parameters(base_bgc; maximum_growth_rate = ((:P_1, :P_2, :extra),))
     @test_throws ArgumentError Agate.Runtime.active_parameters(base_bgc; detritus_remineralization = false)
     @test_throws ArgumentError Agate.Runtime.active_parameters(base_bgc; not_a_parameter = true)
 end
@@ -244,22 +244,22 @@ end
     base_bgc = ActiveParameterNiPiZD.construct()
 
     active = Agate.Runtime.active_parameters(base_bgc;
-        maximum_growth_rate = (:P1, :P2),
+        maximum_growth_rate = (:P_1, :P_2),
         detritus_remineralization = true,
         interactions = (;
-            palatability = ((:Z1, :P1), (:Z1, :P2), (:Z2, :P1)),
-            assimilation = ((:Z1, :P1),),
+            palatability = ((:Z_1, :P_1), (:Z_1, :P_2), (:Z_2, :P_1)),
+            assimilation = ((:Z_1, :P_1),),
         ),
     )
 
     @test active.labels == (
-        "maximum_growth_rate.P1",
-        "maximum_growth_rate.P2",
+        "maximum_growth_rate.P_1",
+        "maximum_growth_rate.P_2",
         "detritus_remineralization",
-        "interactions.palatability[Z1, P1]",
-        "interactions.palatability[Z1, P2]",
-        "interactions.palatability[Z2, P1]",
-        "interactions.assimilation[Z1, P1]",
+        "interactions.palatability[Z_1, P_1]",
+        "interactions.palatability[Z_1, P_2]",
+        "interactions.palatability[Z_2, P_1]",
+        "interactions.assimilation[Z_1, P_1]",
     )
 
     @test length(active) == 7
@@ -303,13 +303,13 @@ end
     )
 
     function runtime_active(bgc, producers, consumers)
-        p1, p2 = producers
-        z1, z2 = consumers
+        producer_1, producer_2 = producers
+        consumer_1, consumer_2 = consumers
         return Agate.Runtime.active_parameters(bgc;
-            maximum_growth_rate=(p1, p2),
+            maximum_growth_rate=(producer_1, producer_2),
             interactions=(;
-                palatability=((z1, p1),),
-                assimilation=((z2, p2),),
+                palatability=((consumer_1, producer_1),),
+                assimilation=((consumer_2, producer_2),),
             ),
         )
     end
@@ -317,7 +317,7 @@ end
     named_active = runtime_active(
         named_bgc, (:diat_1, :dino_1), (:microzoo_1, :mesozoo_1)
     )
-    flat_active = runtime_active(flat_bgc, (:P1, :P2), (:Z1, :Z2))
+    flat_active = runtime_active(flat_bgc, (:P_1, :P_2), (:Z_1, :Z_2))
 
     @test named_active.labels == (
         "maximum_growth_rate.diat_1",
@@ -340,7 +340,7 @@ end
         flat_bgc, p; active_parameters=flat_active
     )
     @test named_parameterized(Val(:diat_1), args...) ≈
-          flat_parameterized(Val(:P1), args...)
+          flat_parameterized(Val(:P_1), args...)
 
     u0 = [7.0, 1.0, 0.05, 0.05, 0.01, 0.01]
     function rhs(bgc, active)

--- a/test/test_active_parameters.jl
+++ b/test/test_active_parameters.jl
@@ -298,8 +298,9 @@ end
         ),
     )
     flat_bgc = ActiveParameterNiPiZD.construct(;
-        phyto_size_structure=[2.0, 10.0],
-        zoo_size_structure=[20.0, 100.0],
+        size_structure=(;
+            phytoplankton=(P=[2.0, 10.0],), zooplankton=(Z=[20.0, 100.0],)
+        )
     )
 
     function runtime_active(bgc, producers, consumers)

--- a/test/test_enzyme.jl
+++ b/test/test_enzyme.jl
@@ -9,15 +9,15 @@ const EnzymeNiPiZD = Agate.Models.NiPiZD
 @testset "Enzyme parameterized tendency gradients" begin
     mu0 = 0.7 / day
     base_bgc = EnzymeNiPiZD.construct(;
-        parameters=(; maximum_growth_rate=(P1=mu0, P2=mu0)),
+        parameters=(; maximum_growth_rate=(P_1=mu0, P_2=mu0)),
     )
 
     active = Agate.Runtime.active_parameters(base_bgc;
-        maximum_growth_rate = (:P1,),
+        maximum_growth_rate = (:P_1,),
         detritus_remineralization = true,
         interactions = (;
-            palatability = ((:Z1, :P1),),
-            assimilation = ((:Z1, :P1),),
+            palatability = ((:Z_1, :P_1),),
+            assimilation = ((:Z_1, :P_1),),
         ),
     )
 
@@ -25,10 +25,10 @@ const EnzymeNiPiZD = Agate.Models.NiPiZD
 
     function diagnostic(p)
         bgc_p = Agate.Runtime.parameterized(base_bgc, p; active_parameters=active)
-        p1 = bgc_p(Val(:P1), args...)
-        z1 = bgc_p(Val(:Z1), args...)
+        p_1 = bgc_p(Val(:P_1), args...)
+        z_1 = bgc_p(Val(:Z_1), args...)
         d = bgc_p(Val(:D), args...)
-        return p1 + 0.5z1 + 0.25d
+        return p_1 + 0.5z_1 + 0.25d
     end
 
     p0 = copy(active.values)

--- a/test/test_forwarddiff.jl
+++ b/test/test_forwarddiff.jl
@@ -8,7 +8,7 @@ const ForwardDiffDARWIN = Agate.Models.DARWIN
 using Oceananigans.Units: day
 
 @testset "ForwardDiff NiPiZD tendency smoke tests" begin
-    function p1_tendency_with_growth_rate(mu)
+    function p_1_tendency_with_growth_rate(mu)
         T = typeof(mu)
         bgc = ForwardDiffNiPiZD.construct(;
             scalar_type=T,
@@ -17,13 +17,13 @@ using Oceananigans.Units: day
 
         N = T(7.0)
         D = T(1.0)
-        Z1 = T(0.05)
-        Z2 = T(0.05)
-        P1 = T(0.01)
-        P2 = T(0.01)
+        Z_1 = T(0.05)
+        Z_2 = T(0.05)
+        P_1 = T(0.01)
+        P_2 = T(0.01)
         PAR = T(100.0)
 
-        return bgc(Val(:P1), 0, 0, 0, 0, N, D, Z1, Z2, P1, P2, PAR)
+        return bgc(Val(:P_1), 0, 0, 0, 0, N, D, Z_1, Z_2, P_1, P_2, PAR)
     end
 
     mu0 = 0.7 / day
@@ -34,23 +34,23 @@ using Oceananigans.Units: day
     )
     @test eltype(bgc0.parameters.maximum_growth_rate) === T0
 
-    dP1_dmu = ForwardDiff.derivative(p1_tendency_with_growth_rate, mu0)
-    @test isfinite(dP1_dmu)
+    dP_1_dmu = ForwardDiff.derivative(p_1_tendency_with_growth_rate, mu0)
+    @test isfinite(dP_1_dmu)
 
     δ = mu0 * 1e-6
     fd =
-        (p1_tendency_with_growth_rate(mu0 + δ) - p1_tendency_with_growth_rate(mu0 - δ)) /
+        (p_1_tendency_with_growth_rate(mu0 + δ) - p_1_tendency_with_growth_rate(mu0 - δ)) /
         (2δ)
-    @test isapprox(dP1_dmu, fd; rtol=1e-4, atol=1e-10)
+    @test isapprox(dP_1_dmu, fd; rtol=1e-4, atol=1e-10)
 end
 
 @testset "ForwardDiff NiPiZD ode_problem active parameter smoke test" begin
     mu0 = 0.7 / day
     base_bgc = ForwardDiffNiPiZD.construct(;
-        parameters=(; maximum_growth_rate=(P1=mu0, P2=mu0)),
+        parameters=(; maximum_growth_rate=(P_1=mu0, P_2=mu0)),
     )
 
-    active_growth = Agate.Runtime.active_parameters(base_bgc; maximum_growth_rate=(:P1,))
+    active_growth = Agate.Runtime.active_parameters(base_bgc; maximum_growth_rate=(:P_1,))
     u0 = [7.0, 1.0, 0.05, 0.05, 0.01, 0.01]
     problem = Agate.Runtime.ode_problem(
         base_bgc,
@@ -61,7 +61,7 @@ end
         auxiliary=(; PAR=100.0),
     )
 
-    function p1_tendency_with_active_growth_rate(mu)
+    function p_1_tendency_with_active_growth_rate(mu)
         T = typeof(mu)
         u = T.(u0)
         du = similar(u)
@@ -69,19 +69,19 @@ end
         return du[5]
     end
 
-    dP1_dmu = ForwardDiff.derivative(p1_tendency_with_active_growth_rate, mu0)
-    @test isfinite(dP1_dmu)
+    dP_1_dmu = ForwardDiff.derivative(p_1_tendency_with_active_growth_rate, mu0)
+    @test isfinite(dP_1_dmu)
 
     δ = mu0 * 1e-6
     fd = (
-        p1_tendency_with_active_growth_rate(mu0 + δ) -
-        p1_tendency_with_active_growth_rate(mu0 - δ)
+        p_1_tendency_with_active_growth_rate(mu0 + δ) -
+        p_1_tendency_with_active_growth_rate(mu0 - δ)
     ) / (2δ)
-    @test isapprox(dP1_dmu, fd; rtol=1e-4, atol=1e-10)
+    @test isapprox(dP_1_dmu, fd; rtol=1e-4, atol=1e-10)
 end
 
 @testset "ForwardDiff DARWIN tendency smoke tests" begin
-    function p1_tendency_with_growth_rate(mu)
+    function p_1_tendency_with_growth_rate(mu)
         T = typeof(mu)
         bgc = ForwardDiffDARWIN.construct(;
             scalar_type=T,
@@ -97,14 +97,14 @@ end
         PON = T(0.01)
         DOP = T(0.001)
         POP = T(0.001)
-        Z1 = T(0.02)
-        Z2 = T(0.02)
-        P1 = T(0.01)
-        P2 = T(0.01)
+        Z_1 = T(0.02)
+        Z_2 = T(0.02)
+        P_1 = T(0.01)
+        P_2 = T(0.01)
         PAR = T(100.0)
 
         return bgc(
-            Val(:P1),
+            Val(:P_1),
             0,
             0,
             0,
@@ -118,10 +118,10 @@ end
             PON,
             DOP,
             POP,
-            Z1,
-            Z2,
-            P1,
-            P2,
+            Z_1,
+            Z_2,
+            P_1,
+            P_2,
             PAR,
         )
     end
@@ -134,12 +134,12 @@ end
     )
     @test eltype(bgc0.parameters.maximum_growth_rate) === T0
 
-    dP1_dmu = ForwardDiff.derivative(p1_tendency_with_growth_rate, mu0)
-    @test isfinite(dP1_dmu)
+    dP_1_dmu = ForwardDiff.derivative(p_1_tendency_with_growth_rate, mu0)
+    @test isfinite(dP_1_dmu)
 
     δ = mu0 * 1e-6
     fd =
-        (p1_tendency_with_growth_rate(mu0 + δ) - p1_tendency_with_growth_rate(mu0 - δ)) /
+        (p_1_tendency_with_growth_rate(mu0 + δ) - p_1_tendency_with_growth_rate(mu0 - δ)) /
         (2δ)
-    @test isapprox(dP1_dmu, fd; rtol=1e-4, atol=1e-10)
+    @test isapprox(dP_1_dmu, fd; rtol=1e-4, atol=1e-10)
 end

--- a/test/test_introspection.jl
+++ b/test/test_introspection.jl
@@ -14,13 +14,13 @@ using Test
     @testset "Model-constructed instance" begin
         bgc = Agate.Models.NiPiZD.construct(; grid=dummy_grid(Float32))
 
-        @test tracer_names(bgc) == [:N, :D, :Z1, :Z2, :P1, :P2]
+        @test tracer_names(bgc) == [:N, :D, :Z_1, :Z_2, :P_1, :P_2]
 
         groups = tracer_groups(bgc)
         @test groups.all == tracer_names(bgc)
-        @test groups.by_group.Z == [:Z1, :Z2]
-        @test groups.by_group.P == [:P1, :P2]
-        @test groups.plankton == [:Z1, :Z2, :P1, :P2]
+        @test groups.by_group.Z == [:Z_1, :Z_2]
+        @test groups.by_group.P == [:P_1, :P_2]
+        @test groups.plankton == [:Z_1, :Z_2, :P_1, :P_2]
         @test groups.nonplankton == [:N, :D]
         @test plankton_groups(bgc) == groups.by_group
         @test plankton_tracers(bgc) == groups.plankton
@@ -38,8 +38,8 @@ using Test
 
         @test pal.kind == :palatability
         @test assim.kind == :assimilation
-        @test pal.rows == [:Z1, :Z2]
-        @test pal.columns == [:P1, :P2]
+        @test pal.rows == [:Z_1, :Z_2]
+        @test pal.columns == [:P_1, :P_2]
         @test assim.rows == pal.rows
         @test assim.columns == pal.columns
         @test pal.row_axis == :consumer
@@ -75,7 +75,7 @@ using Test
         sized_bgc = Agate.Models.NiPiZD.construct(;
             phyto_size_structure=phyto_diameters, zoo_size_structure=zoo_diameters
         )
-        @test plankton_tracers(sized_bgc) == [:Z1, :Z2, :P1, :P2, :P3]
+        @test plankton_tracers(sized_bgc) == [:Z_1, :Z_2, :P_1, :P_2, :P_3]
         @test plankton_diameters(sized_bgc) ≈ [zoo_diameters; phyto_diameters]
 
         named_bgc = Agate.Models.NiPiZD.construct(;

--- a/test/test_introspection.jl
+++ b/test/test_introspection.jl
@@ -73,7 +73,9 @@ using Test
         phyto_diameters = [2.0, sqrt(20.0), 10.0]
         zoo_diameters = [20.0, 100.0]
         sized_bgc = Agate.Models.NiPiZD.construct(;
-            phyto_size_structure=phyto_diameters, zoo_size_structure=zoo_diameters
+            size_structure=(;
+                phytoplankton=(P=phyto_diameters,), zooplankton=(Z=zoo_diameters,)
+            )
         )
         @test plankton_tracers(sized_bgc) == [:Z_1, :Z_2, :P_1, :P_2, :P_3]
         @test plankton_diameters(sized_bgc) ≈ [zoo_diameters; phyto_diameters]

--- a/test/test_mass_balance.jl
+++ b/test/test_mass_balance.jl
@@ -21,9 +21,9 @@ using Oceananigans
     @testset "NiPiZD box model" begin
         bgc_instance = NiPiZD.construct()
         box_model = build_box_model(bgc_instance)
-        set!(box_model; N=7, P1=0.01, P2=0.01, Z1=0.05, Z2=0.05, D=0.0)
+        set!(box_model; N=7, P_1=0.01, P_2=0.01, Z_1=0.05, Z_2=0.05, D=0.0)
 
-        budgets = (total=[:N => 1, :P1 => 1, :P2 => 1, :Z1 => 1, :Z2 => 1, :D => 1],)
+        budgets = (total=[:N => 1, :P_1 => 1, :P_2 => 1, :Z_1 => 1, :Z_2 => 1, :D => 1],)
 
         result = box_model_mass_balance(box_model, budgets; dt=0.1, nsteps=1000)
         @test isapprox(result.initial.total, result.final.total; rtol=1e-12, atol=0.0)
@@ -36,10 +36,10 @@ using Oceananigans
             box_model;
             DIN=7,
             PO4=3,
-            P1=0.01,
-            P2=0.01,
-            Z1=0.05,
-            Z2=0.05,
+            P_1=0.01,
+            P_2=0.01,
+            Z_1=0.05,
+            Z_2=0.05,
             DOC=0.0,
             POC=0.0,
             DON=0.0,
@@ -53,23 +53,23 @@ using Oceananigans
 
         budgets = (
             carbon=[
-                :DIC => 1, :P1 => 1, :P2 => 1, :Z1 => 1, :Z2 => 1, :POC => 1, :DOC => 1
+                :DIC => 1, :P_1 => 1, :P_2 => 1, :Z_1 => 1, :Z_2 => 1, :POC => 1, :DOC => 1
             ],
             nitrogen=[
                 :DIN => 1,
-                :P1 => n2c,
-                :P2 => n2c,
-                :Z1 => n2c,
-                :Z2 => n2c,
+                :P_1 => n2c,
+                :P_2 => n2c,
+                :Z_1 => n2c,
+                :Z_2 => n2c,
                 :PON => 1,
                 :DON => 1,
             ],
             phosphorus=[
                 :PO4 => 1,
-                :P1 => p2c,
-                :P2 => p2c,
-                :Z1 => p2c,
-                :Z2 => p2c,
+                :P_1 => p2c,
+                :P_2 => p2c,
+                :Z_1 => p2c,
+                :Z_2 => p2c,
                 :POP => 1,
                 :DOP => 1,
             ],

--- a/test/test_model_setup_manifest.jl
+++ b/test/test_model_setup_manifest.jl
@@ -11,7 +11,7 @@ end
 @testset "NiPiZD model setup export and import" begin
     grid = BoxModelGrid()
     palatability_matrix = Float32[0.8 0.2; 0.3 0.7]
-    sinking_tracers = (P1=0.125f0 / day, D=1.5f0 / day)
+    sinking_tracers = (P_1=0.125f0 / day, D=1.5f0 / day)
 
     bgc, setup = Agate.Models.NiPiZD.construct_with_manifest(
         ;
@@ -30,12 +30,12 @@ end
     @test reconstructed.parameters.palatability_matrix ≈ palatability_matrix
     @test !isnothing(reconstructed.sinking_velocities)
 
-    reconstructed_P1 = biogeochemical_drift_velocity(reconstructed, Val(:P1)).w.data[1, 1, 1]
+    reconstructed_P_1 = biogeochemical_drift_velocity(reconstructed, Val(:P_1)).w.data[1, 1, 1]
     reconstructed_D = biogeochemical_drift_velocity(reconstructed, Val(:D)).w.data[1, 1, 1]
 
-    @test reconstructed_P1 ≈ biogeochemical_drift_velocity(bgc, Val(:P1)).w.data[1, 1, 1]
+    @test reconstructed_P_1 ≈ biogeochemical_drift_velocity(bgc, Val(:P_1)).w.data[1, 1, 1]
     @test reconstructed_D ≈ biogeochemical_drift_velocity(bgc, Val(:D)).w.data[1, 1, 1]
-    @test reconstructed_P1 ≈ -sinking_tracers.P1
+    @test reconstructed_P_1 ≈ -sinking_tracers.P_1
     @test reconstructed_D ≈ -sinking_tracers.D
 end
 

--- a/test/test_models_construct.jl
+++ b/test/test_models_construct.jl
@@ -20,25 +20,25 @@ using Oceananigans.Biogeochemistry:
         # Guardrail for GPU compilation: tracer callables must be concretely typed.
         @test !any(t -> t === Any, fieldtypes(typeof(bgc.tracer_functions)))
 
-        @test required_biogeochemical_tracers(bgc) == (:N, :D, :Z1, :Z2, :P1, :P2)
+        @test required_biogeochemical_tracers(bgc) == (:N, :D, :Z_1, :Z_2, :P_1, :P_2)
 
-        P1 = 0.01f0
-        P2 = 0.01f0
-        Z1 = 0.05f0
-        Z2 = 0.05f0
+        P_1 = 0.01f0
+        P_2 = 0.01f0
+        Z_1 = 0.05f0
+        Z_2 = 0.05f0
         N = 7.0f0
         D = 1.0f0
         PAR = 100.0f0
 
         tracer_vals(sym) =
-            if sym === :P1
-                P1
-            elseif sym === :P2
-                P2
-            elseif sym === :Z1
-                Z1
-            elseif sym === :Z2
-                Z2
+            if sym === :P_1
+                P_1
+            elseif sym === :P_2
+                P_2
+            elseif sym === :Z_1
+                Z_1
+            elseif sym === :Z_2
+                Z_2
             elseif sym === :N
                 N
             else
@@ -49,8 +49,8 @@ using Oceananigans.Biogeochemistry:
 
         @test isfinite(bgc(Val(:N), 0, 0, 0, 0, ordered..., PAR))
         @test isfinite(bgc(Val(:D), 0, 0, 0, 0, ordered..., PAR))
-        @test isfinite(bgc(Val(:P1), 0, 0, 0, 0, ordered..., PAR))
-        @test isfinite(bgc(Val(:Z1), 0, 0, 0, 0, ordered..., PAR))
+        @test isfinite(bgc(Val(:P_1), 0, 0, 0, 0, ordered..., PAR))
+        @test isfinite(bgc(Val(:Z_1), 0, 0, 0, 0, ordered..., PAR))
     end
 
     @testset "NiPiZD named size structure" begin
@@ -71,7 +71,7 @@ using Oceananigans.Biogeochemistry:
         )
 
         @test required_biogeochemical_tracers(default_groups) ==
-            (:N, :D, :Z1, :Z2, :P1, :P2)
+            (:N, :D, :Z_1, :Z_2, :P_1, :P_2)
         @test required_biogeochemical_tracers(named_equivalent) ==
             (:N, :D, :Z_1, :Z_2, :P_1, :P_2)
         @test named_equivalent.parameters.maximum_growth_rate ==
@@ -323,8 +323,8 @@ using Oceananigans.Biogeochemistry:
         bgc_named = NiPiZD.construct(;
             grid=dummy_grid(Float32),
             parameters=(;
-                optimum_predator_prey_ratio=(Z1=5.0, Z2=5.0),
-                maximum_growth_rate=(P1=1.2 / day,),
+                optimum_predator_prey_ratio=(Z_1=5.0, Z_2=5.0),
+                maximum_growth_rate=(P_1=1.2 / day,),
             ),
         )
         bgc_positional = NiPiZD.construct(;
@@ -350,7 +350,7 @@ using Oceananigans.Biogeochemistry:
 
         dar_named = DARWIN.construct(;
             grid=dummy_grid(Float32),
-            parameters=(; specificity=(Z1=2.0, Z2=2.5), half_saturation_DIN=(P2=0.3,)),
+            parameters=(; specificity=(Z_1=2.0, Z_2=2.5), half_saturation_DIN=(P_2=0.3,)),
         )
         dar_positional = DARWIN.construct(;
             grid=dummy_grid(Float32),
@@ -365,21 +365,21 @@ using Oceananigans.Biogeochemistry:
         err = try
             NiPiZD.construct(;
                 grid=dummy_grid(Float32),
-                parameters=(; optimum_predator_prey_ratio=(Z3=5.0,)),
+                parameters=(; optimum_predator_prey_ratio=(Z_3=5.0,)),
             )
             nothing
         catch e
             e
         end
         @test err isa ArgumentError
-        @test occursin("Unknown key `Z3`", sprint(showerror, err))
-        @test occursin("Z1, Z2, P1, P2", sprint(showerror, err))
+        @test occursin("Unknown key `Z_3`", sprint(showerror, err))
+        @test occursin("Z_1, Z_2, P_1, P_2", sprint(showerror, err))
 
         @test_throws ArgumentError NiPiZD.construct(;
-            grid=dummy_grid(Float32), parameters=(; detritus_remineralization=(Z1=1.0,))
+            grid=dummy_grid(Float32), parameters=(; detritus_remineralization=(Z_1=1.0,))
         )
         @test_throws ArgumentError NiPiZD.construct(;
-            grid=dummy_grid(Float32), parameters=(; palatability_matrix=(Z1=(P1=1.0,),))
+            grid=dummy_grid(Float32), parameters=(; palatability_matrix=(Z_1=(P_1=1.0,),))
         )
     end
 
@@ -440,7 +440,7 @@ using Oceananigans.Biogeochemistry:
             phyto_size_structure=phyto_diameters,
             zoo_size_structure=zoo_diameters,
             grid=dummy_grid(Float32),
-            parameters=(; maximum_growth_rate=(P1=1.2 / day,)),
+            parameters=(; maximum_growth_rate=(P_1=1.2 / day,)),
         )
 
         @test bgc_full_vector.parameters.maximum_growth_rate == expected_growth
@@ -467,17 +467,17 @@ using Oceananigans.Biogeochemistry:
 
     @testset "NiPiZD community structure overrides" begin
         bgc = NiPiZD.construct(; phyto_size_structure=[3.0], grid=dummy_grid(Float32))
-        @test required_biogeochemical_tracers(bgc) == (:N, :D, :Z1, :Z2, :P1)
+        @test required_biogeochemical_tracers(bgc) == (:N, :D, :Z_1, :Z_2, :P_1)
     end
 
     @testset "NiPiZD sinking" begin
         bgc = NiPiZD.construct(;
-            sinking_tracers=(P1=0.2551 / day, P2=0.2551 / day, D=2.7489 / day)
+            sinking_tracers=(P_1=0.2551 / day, P_2=0.2551 / day, D=2.7489 / day)
         )
 
-        @test biogeochemical_drift_velocity(bgc, Val(:P1)).w.data[1, 1, 1] == -0.2551 / day
+        @test biogeochemical_drift_velocity(bgc, Val(:P_1)).w.data[1, 1, 1] == -0.2551 / day
         @test biogeochemical_drift_velocity(bgc, Val(:D)).w.data[1, 1, 1] == -2.7489 / day
-        @test biogeochemical_drift_velocity(bgc, Val(:Z1)).w == ZeroField()
+        @test biogeochemical_drift_velocity(bgc, Val(:Z_1)).w == ZeroField()
     end
 
     @testset "DARWIN defaults" begin

--- a/test/test_models_construct.jl
+++ b/test/test_models_construct.jl
@@ -53,35 +53,19 @@ using Oceananigans.Biogeochemistry:
         @test isfinite(bgc(Val(:Z_1), 0, 0, 0, 0, ordered..., PAR))
     end
 
-    @testset "NiPiZD named size structure" begin
+    @testset "NiPiZD size structure" begin
         phyto_diameters = [2.0, 10.0]
         zoo_diameters = [20.0, 100.0]
 
         default_groups = NiPiZD.construct(;
-            phyto_size_structure=phyto_diameters,
-            zoo_size_structure=zoo_diameters,
-            grid=dummy_grid(Float32),
-        )
-        named_equivalent = NiPiZD.construct(;
             size_structure=(;
                 phytoplankton=(P=phyto_diameters,),
                 zooplankton=(Z=zoo_diameters,),
             ),
             grid=dummy_grid(Float32),
         )
-
         @test required_biogeochemical_tracers(default_groups) ==
             (:N, :D, :Z_1, :Z_2, :P_1, :P_2)
-        @test required_biogeochemical_tracers(named_equivalent) ==
-            (:N, :D, :Z_1, :Z_2, :P_1, :P_2)
-        @test named_equivalent.parameters.maximum_growth_rate ==
-            default_groups.parameters.maximum_growth_rate
-        @test named_equivalent.parameters.maximum_predation_rate ==
-            default_groups.parameters.maximum_predation_rate
-        @test named_equivalent.parameters.interactions.palatability ==
-            default_groups.parameters.interactions.palatability
-        @test named_equivalent.parameters.interactions.assimilation ==
-            default_groups.parameters.interactions.assimilation
 
         named = NiPiZD.construct(;
             size_structure=(;
@@ -108,22 +92,6 @@ using Oceananigans.Biogeochemistry:
         @test count(x -> x != 0, named.parameters.maximum_growth_rate) == 5
         @test count(x -> x != 0, named.parameters.maximum_predation_rate) == 3
 
-        explicit_nothing = NiPiZD.construct(;
-            phyto_size_structure=nothing,
-            zoo_size_structure=nothing,
-            grid=dummy_grid(Float32),
-        )
-        default_model = NiPiZD.construct(; grid=dummy_grid(Float32))
-        @test required_biogeochemical_tracers(explicit_nothing) ==
-            required_biogeochemical_tracers(default_model)
-
-        @test_throws ArgumentError NiPiZD.construct(;
-            size_structure=(;
-                phytoplankton=(diat=[2.0],),
-                zooplankton=(microzoo=[30.0],),
-            ),
-            phyto_size_structure=[2.0],
-        )
         invalid_size_structures = (
             1,
             (; phytoplankton=(diat=[2.0],)),
@@ -142,7 +110,7 @@ using Oceananigans.Biogeochemistry:
         end
     end
 
-    @testset "NiPiZD named parameter semantics" begin
+    @testset "NiPiZD grouped parameter semantics" begin
         phyto_diameters = [2.0, 5.0, 10.0]
         zoo_diameters = [30.0, 60.0, 100.0]
         named_size_structure = (;
@@ -163,8 +131,10 @@ using Oceananigans.Biogeochemistry:
         end
 
         flat = NiPiZD.construct(;
-            phyto_size_structure=phyto_diameters,
-            zoo_size_structure=zoo_diameters,
+            size_structure=(;
+                phytoplankton=(P=phyto_diameters,),
+                zooplankton=(Z=zoo_diameters,),
+            ),
             grid=dummy_grid(Float32),
         )
         named = NiPiZD.construct(;
@@ -386,6 +356,9 @@ using Oceananigans.Biogeochemistry:
     @testset "Allometric parameter overrides" begin
         phyto_diameters = [2.0, 8.0]
         zoo_diameters = [20.0, 100.0]
+        size_structure = (;
+            phytoplankton=(P=phyto_diameters,), zooplankton=(Z=zoo_diameters,)
+        )
 
         powerlaw_value(T, prefactor, exponent, diameter) = begin
             d = T(diameter)
@@ -399,8 +372,7 @@ using Oceananigans.Biogeochemistry:
         predation_exponent = -0.16
 
         bgc = NiPiZD.construct(;
-            phyto_size_structure=phyto_diameters,
-            zoo_size_structure=zoo_diameters,
+            size_structure,
             grid=dummy_grid(Float32),
             parameters=(;
                 maximum_growth_rate=AllometricParam(
@@ -431,14 +403,12 @@ using Oceananigans.Biogeochemistry:
         @test eltype(bgc.parameters.maximum_predation_rate) === Float32
 
         bgc_full_vector = NiPiZD.construct(;
-            phyto_size_structure=phyto_diameters,
-            zoo_size_structure=zoo_diameters,
+            size_structure,
             grid=dummy_grid(Float32),
             parameters=(; maximum_growth_rate=expected_growth),
         )
         bgc_named = NiPiZD.construct(;
-            phyto_size_structure=phyto_diameters,
-            zoo_size_structure=zoo_diameters,
+            size_structure,
             grid=dummy_grid(Float32),
             parameters=(; maximum_growth_rate=(P_1=1.2 / day,)),
         )
@@ -466,7 +436,12 @@ using Oceananigans.Biogeochemistry:
 
 
     @testset "NiPiZD community structure overrides" begin
-        bgc = NiPiZD.construct(; phyto_size_structure=[3.0], grid=dummy_grid(Float32))
+        bgc = NiPiZD.construct(;
+            size_structure=(;
+                phytoplankton=(P=[3.0],), zooplankton=(Z=[20.0, 100.0],)
+            ),
+            grid=dummy_grid(Float32),
+        )
         @test required_biogeochemical_tracers(bgc) == (:N, :D, :Z_1, :Z_2, :P_1)
     end
 
@@ -518,10 +493,16 @@ using Oceananigans.Biogeochemistry:
 
     @testset "Input validation" begin
         @test_throws ArgumentError NiPiZD.construct(;
-            phyto_size_structure=(n=0, min_esd=2, max_esd=10, splitting=:log_splitting)
+            size_structure=(;
+                phytoplankton=(P=(n=0, min_esd=2, max_esd=10, splitting=:log_splitting),),
+                zooplankton=(Z=[20.0, 100.0],),
+            )
         )
         @test_throws ArgumentError NiPiZD.construct(;
-            zoo_size_structure=(n=0, min_esd=20, max_esd=100, splitting=:linear_splitting)
+            size_structure=(;
+                phytoplankton=(P=[2.0, 10.0],),
+                zooplankton=(Z=(n=0, min_esd=20, max_esd=100, splitting=:linear_splitting),),
+            )
         )
 
         # Grid determines precision unless an explicit scalar type is supplied.


### PR DESCRIPTION
* Standardizes plankton tracer naming to a single `<group>_<index>` convention.
* Updates default phytoplankton tracers:

  * `P1` → `P_1`
  * `P2` → `P_2`
  * subsequent groups follow the same pattern.
* Updates default zooplankton tracers:

  * `Z1` → `Z_1`
  * `Z2` → `Z_2`
  * subsequent groups follow the same pattern.
* Simplifies community parsing so all plankton tracer names are generated directly from the group name and class index.
* Removes the separate custom `tracer_names` parsing path.
* Simplifies NiPiZD size-structure configuration so default `P`/`Z` groups and named groups use the same construction path.
* Adds a shared default NiPiZD `size_structure`, with phytoplankton and zooplankton roles represented explicitly as `P` and `Z` groups.
* Retains support for defining individual group sizes either from a size-structure specification or from an explicit array of class sizes.
* Updates tracer references across runtime configuration, tests, examples, documentation, diagnostics, and paper scripts.
* Aligns tracer-derived local variable names with the new convention for clarity.

Breaking changes:

* Renames default plankton tracer symbols throughout Agate:

  * `P1`, `P2`, … → `P_1`, `P_2`, …
  * `Z1`, `Z2`, … → `Z_1`, `Z_2`, …
* Updates corresponding parameter keys, active-parameter selectors, interaction definitions, diagnostic references, and model setup manifests to use the new tracer names.
* Removes the NiPiZD `phyto_size_structure` and `zoo_size_structure` constructor keywords in favor of the unified `size_structure` interface.
* Removes explicit per-group `tracer_names` configuration; plankton tracer names are now derived consistently from `<group>_<index>`.
