### PR TITLE
Fix seg fault bug

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,3 +47,25 @@ jobs:
 
           Agate.Models.NiPiZD.construct(grid=nothing)
           Agate.Models.DARWIN.construct(grid=nothing)
+
+  compatibility-112:
+    name: Julia 1.12 - compatibility smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1.12'
+          arch: x64
+      - uses: julia-actions/cache@v1
+      - name: Instantiate, precompile, load, and construct models
+        shell: julia --project=. --color=yes {0}
+        run: |
+          using Pkg
+          Pkg.instantiate()
+          Pkg.precompile()
+
+          using Agate
+
+          Agate.Models.NiPiZD.construct(grid=nothing)
+          Agate.Models.DARWIN.construct(grid=nothing)

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Agate"
 uuid = "41889b7c-c35c-4f16-abd7-94b299d9fd29"
-version = "0.8.1"
+version = "0.8.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ ForwardDiff = "1"
 OceanBioME = "0.16"
 Oceananigans = "0.101.1, 0.102"
 SciMLBase = "2"
-julia = "1.10 - 1.11"
+julia = "1.10"
 
 [extras]
 Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"

--- a/src/Construction/construct.jl
+++ b/src/Construction/construct.jl
@@ -580,10 +580,10 @@ function _construct_factory(
     tracer_names = (keys(biogeochem_dynamics)..., Tuple(plankton_syms)...)
     tracer_defs = ()
 
-    for (_, f) in pairs(biogeochem_dynamics)
+    for (k, f) in pairs(biogeochem_dynamics)
         tr = f()
         (tr isa CompiledEquation) || throw(
-            ArgumentError("biogeochem dynamics $(nameof(f)) must return CompiledEquation"),
+            ArgumentError("biogeochem dynamics :$k must return CompiledEquation"),
         )
         tracer_defs = (tracer_defs..., tr)
     end
@@ -593,7 +593,7 @@ function _construct_factory(
         f = getfield(plankton_dynamics, g)
         tr = f(idx)
         (tr isa CompiledEquation) || throw(
-            ArgumentError("plankton dynamics $(nameof(f)) must return CompiledEquation")
+            ArgumentError("plankton dynamics :$g must return CompiledEquation")
         )
         tracer_defs = (tracer_defs..., tr)
     end


### PR DESCRIPTION
* Avoids a Julia 1.12 segmentation fault during model construction, caused by calling `nameof` on an anonymous dynamics-builder closure inside a compiled loop.
* Adds a lightweight Julia 1.12 compatibility CI lane that instantiates and precompiles Agate, loads the package, and constructs the default `NiPiZD` and `DARWIN` models, mirroring the existing Julia 1.11 lane.
* Widens the `julia` compat bound from `1.10 - 1.11` to `1.10`, removing the explicit upper cap now that the 1.12 crash is fixed.
