### PR TITLE
Numerical robustness and type genericity

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Agate"
 uuid = "41889b7c-c35c-4f16-abd7-94b299d9fd29"
-version = "0.8.2"
+version = "0.8.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/Diagnostics/box_model.jl
+++ b/src/Diagnostics/box_model.jl
@@ -15,13 +15,21 @@ This is intended as a small helper for mass/budget diagnostics and tests.
 function box_model_budget(box_model, terms; location::NTuple{3,Int}=(1, 1, 1))
     i, j, k = location
     pairs_iter = terms isa NamedTuple ? pairs(terms) : terms
+    first_term = iterate(pairs_iter)
+    first_term === nothing && return 0.0
 
-    s = 0.0
-    for (tracer, weight) in pairs_iter
+    ((tracer, weight), state) = first_term
+    fld = getproperty(box_model.fields, tracer)
+    budget = weight * fld.data[i, j, k]
+
+    while true
+        next_term = iterate(pairs_iter, state)
+        next_term === nothing && return budget
+
+        ((tracer, weight), state) = next_term
         fld = getproperty(box_model.fields, tracer)
-        s += float(weight) * float(fld.data[i, j, k])
+        budget += weight * fld.data[i, j, k]
     end
-    return s
 end
 
 """

--- a/src/Library/nutrients.jl
+++ b/src/Library/nutrients.jl
@@ -96,7 +96,7 @@ struct SmoothLiebigMinimum{S}
     sharpness::S
 end
 
-@inline SmoothLiebigMinimum() = SmoothLiebigMinimum(50.0)
+@inline SmoothLiebigMinimum() = SmoothLiebigMinimum(50)
 
 @inline function (l::SmoothLiebigMinimum)(a, b)
     s = l.sharpness
@@ -145,16 +145,16 @@ This is an explicit alias around `LiebigMinimum()` for clearer model code.
 @inline liebig_minimum(values::Tuple{Vararg{Any,N}}) where N = LiebigMinimum()(values)
 
 """
-    smooth_liebig_minimum(a, b, rest...; sharpness = 50.0)
-    smooth_liebig_minimum(values::NTuple; sharpness = 50.0)
+    smooth_liebig_minimum(a, b, rest...; sharpness = 50)
+    smooth_liebig_minimum(values::NTuple; sharpness = 50)
 
 Return a smooth approximation to the minimum value among the given limitation
 factors. Larger `sharpness` values approach `liebig_minimum`.
 """
-@inline smooth_liebig_minimum(a, b; sharpness=50.0) = SmoothLiebigMinimum(sharpness)(a, b)
+@inline smooth_liebig_minimum(a, b; sharpness=50) = SmoothLiebigMinimum(sharpness)(a, b)
 
-@inline smooth_liebig_minimum(a, b, c, rest...; sharpness=50.0) = SmoothLiebigMinimum(sharpness)(a, b, c, rest...)
+@inline smooth_liebig_minimum(a, b, c, rest...; sharpness=50) = SmoothLiebigMinimum(sharpness)(a, b, c, rest...)
 
-@inline smooth_liebig_minimum(values::Tuple{Vararg{Any,N}}; sharpness=50.0) where N = SmoothLiebigMinimum(sharpness)(values)
+@inline smooth_liebig_minimum(values::Tuple{Vararg{Any,N}}; sharpness=50) where N = SmoothLiebigMinimum(sharpness)(values)
 
 end # module

--- a/src/Library/nutrients.jl
+++ b/src/Library/nutrients.jl
@@ -64,7 +64,14 @@ Liebig's law of the minimum: return the minimum of nutrient limitation factors.
 """
 struct LiebigMinimum end
 
-@inline (l::LiebigMinimum)(a, b) = ifelse(a < b, a, b)
+@inline function (l::LiebigMinimum)(a, b)
+    if isnan(a)
+        return a
+    elseif isnan(b)
+        return b
+    end
+    return ifelse(a < b, a, b)
+end
 
 @inline function (l::LiebigMinimum)(a, b, c, rest...)
     return l(l(a, b), c, rest...)

--- a/src/Library/nutrients.jl
+++ b/src/Library/nutrients.jl
@@ -65,12 +65,8 @@ Liebig's law of the minimum: return the minimum of nutrient limitation factors.
 struct LiebigMinimum end
 
 @inline function (l::LiebigMinimum)(a, b)
-    if isnan(a)
-        return a
-    elseif isnan(b)
-        return b
-    end
-    return ifelse(a < b, a, b)
+    m = ifelse(a < b, a, b)
+    return ifelse(isnan(a) | isnan(b), a + b, m)
 end
 
 @inline function (l::LiebigMinimum)(a, b, c, rest...)

--- a/test/test_library.jl
+++ b/test/test_library.jl
@@ -2,12 +2,9 @@ using Agate
 using Test
 using ForwardDiff
 
-using Agate.Library.Mortality: linear_loss
-using Agate.Library.Nutrients: liebig_minimum, monod_limitation, smooth_liebig_minimum
-using Agate.Library.Photosynthesis: liebig_nutrient_limitation, smooth_liebig_nutrient_limitation, smith_light_limitation
+using Agate.Library.Nutrients: liebig_minimum, smooth_liebig_minimum
+using Agate.Library.Photosynthesis: liebig_nutrient_limitation, smooth_liebig_nutrient_limitation
 using Agate.Library.Predation: holling_type_ii, idealized_predation_loss
-using Agate.Library.Remineralization: linear_remineralization
-using Agate.Library.Temperature: q10_temperature_factor
 
 @testset "Library" begin
     @test holling_type_ii(1.0, 1.0) == 0.5
@@ -19,14 +16,14 @@ end
 @testset "Library scalar genericity" begin
     T = Float32
 
-    @test monod_limitation(T(1), T(0.5)) isa T
-    @test smooth_liebig_minimum(T(0.2), T(0.4)) isa T
-    @test smooth_liebig_nutrient_limitation(
+    @test Agate.Library.Nutrients.monod_limitation(T(1), T(0.5)) isa T
+    @test Agate.Library.Nutrients.smooth_liebig_minimum(T(0.2), T(0.4)) isa T
+    @test Agate.Library.Photosynthesis.smooth_liebig_nutrient_limitation(
         (T(1), T(2)), (T(0.5), T(1)), one(T)
     ) isa T
-    @test smith_light_limitation(T(50), T(0.1), T(1)) isa T
-    @test linear_loss(T(1), T(0.1)) isa T
-    @test holling_type_ii(T(1), T(0.5)) isa T
-    @test linear_remineralization(T(1), T(0.1)) isa T
-    @test q10_temperature_factor(T(10), T(2)) isa T
+    @test Agate.Library.Photosynthesis.smith_light_limitation(T(50), T(0.1), T(1)) isa T
+    @test Agate.Library.Mortality.linear_loss(T(1), T(0.1)) isa T
+    @test Agate.Library.Predation.holling_type_ii(T(1), T(0.5)) isa T
+    @test Agate.Library.Remineralization.linear_remineralization(T(1), T(0.1)) isa T
+    @test Agate.Library.Temperature.q10_temperature_factor(T(10), T(2)) isa T
 end

--- a/test/test_library.jl
+++ b/test/test_library.jl
@@ -2,9 +2,12 @@ using Agate
 using Test
 using ForwardDiff
 
-using Agate.Library.Nutrients: liebig_minimum, smooth_liebig_minimum
-using Agate.Library.Photosynthesis: liebig_nutrient_limitation, smooth_liebig_nutrient_limitation
+using Agate.Library.Mortality: linear_loss
+using Agate.Library.Nutrients: liebig_minimum, monod_limitation, smooth_liebig_minimum
+using Agate.Library.Photosynthesis: liebig_nutrient_limitation, smooth_liebig_nutrient_limitation, smith_light_limitation
 using Agate.Library.Predation: holling_type_ii, idealized_predation_loss
+using Agate.Library.Remineralization: linear_remineralization
+using Agate.Library.Temperature: q10_temperature_factor
 
 @testset "Library" begin
     @test holling_type_ii(1.0, 1.0) == 0.5
@@ -13,3 +16,17 @@ using Agate.Library.Predation: holling_type_ii, idealized_predation_loss
     @test loss > 0
 end
 
+@testset "Library scalar genericity" begin
+    T = Float32
+
+    @test monod_limitation(T(1), T(0.5)) isa T
+    @test smooth_liebig_minimum(T(0.2), T(0.4)) isa T
+    @test smooth_liebig_nutrient_limitation(
+        (T(1), T(2)), (T(0.5), T(1)), one(T)
+    ) isa T
+    @test smith_light_limitation(T(50), T(0.1), T(1)) isa T
+    @test linear_loss(T(1), T(0.1)) isa T
+    @test holling_type_ii(T(1), T(0.5)) isa T
+    @test linear_remineralization(T(1), T(0.1)) isa T
+    @test q10_temperature_factor(T(10), T(2)) isa T
+end

--- a/test/test_mass_balance.jl
+++ b/test/test_mass_balance.jl
@@ -9,29 +9,48 @@ using Agate.Diagnostics: box_model_mass_balance
 using OceanBioME
 using OceanBioME: Biogeochemistry
 using Oceananigans
+using Oceananigans.Units: day, minutes
 
 @testset "mass_balance" begin
-    function build_box_model(bgc_instance)
+    function build_box_model(bgc_instance, grid)
         bgc_model = Biogeochemistry(
-            bgc_instance; light_attenuation=FunctionFieldPAR(; grid=BoxModelGrid())
+            bgc_instance; light_attenuation=FunctionFieldPAR(; grid)
         )
-        return BoxModel(; biogeochemistry=bgc_model)
+        return BoxModel(; biogeochemistry=bgc_model, grid)
     end
 
+    dt = 10minutes
+    nsteps = Int(10day ÷ dt)
+
     @testset "NiPiZD box model" begin
-        bgc_instance = NiPiZD.construct()
-        box_model = build_box_model(bgc_instance)
+        grid = BoxModelGrid()
+        bgc_instance = NiPiZD.construct(; grid)
+        box_model = build_box_model(bgc_instance, grid)
         set!(box_model; N=7, P_1=0.01, P_2=0.01, Z_1=0.05, Z_2=0.05, D=0.0)
 
         budgets = (total=[:N => 1, :P_1 => 1, :P_2 => 1, :Z_1 => 1, :Z_2 => 1, :D => 1],)
 
-        result = box_model_mass_balance(box_model, budgets; dt=0.1, nsteps=1000)
+        result = box_model_mass_balance(box_model, budgets; dt, nsteps)
         @test isapprox(result.initial.total, result.final.total; rtol=1e-12, atol=0.0)
     end
 
+    @testset "NiPiZD Float32 conservation" begin
+        grid = BoxModelGrid(Float32)
+        bgc_instance = NiPiZD.construct(; grid, scalar_type=Float32)
+        box_model = build_box_model(bgc_instance, grid)
+        set!(box_model; N=7f0, P_1=0.01f0, P_2=0.01f0, Z_1=0.05f0, Z_2=0.05f0, D=0f0)
+
+        budgets = (total=[:N => 1, :P_1 => 1, :P_2 => 1, :Z_1 => 1, :Z_2 => 1, :D => 1],)
+
+        result = box_model_mass_balance(box_model, budgets; dt, nsteps)
+        @test result.initial.total isa Float32
+        @test isapprox(result.initial.total, result.final.total; rtol=1e-5, atol=0.0)
+    end
+
     @testset "DARWIN model" begin
-        bgc_instance = DARWIN.construct()
-        box_model = build_box_model(bgc_instance)
+        grid = BoxModelGrid()
+        bgc_instance = DARWIN.construct(; grid)
+        box_model = build_box_model(bgc_instance, grid)
         set!(
             box_model;
             DIN=7,
@@ -75,7 +94,7 @@ using Oceananigans
             ],
         )
 
-        result = box_model_mass_balance(box_model, budgets; dt=1.0, nsteps=1000)
+        result = box_model_mass_balance(box_model, budgets; dt, nsteps)
         rtol = 1e-6
         @test isapprox(result.initial.carbon, result.final.carbon; rtol=rtol)
         @test isapprox(result.initial.nitrogen, result.final.nitrogen; rtol=rtol)


### PR DESCRIPTION
* Preserve Float32 arithmetic in smooth-Liebig nutrient limitation by removing accidental Float64 defaults.
* Make hard Liebig limitation propagate NaN consistently regardless of operand order.
* Preserve scalar types in box-model budget diagnostics instead of forcing Float64 accumulation.
* Strengthen NiPiZD and DARWIN conservation coverage with 10-day box-model integrations.
* Add Float32 NiPiZD conservation coverage and verify Float32 budget diagnostics.