### PR TITLE
Manifest replay correctnes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Agate"
 uuid = "41889b7c-c35c-4f16-abd7-94b299d9fd29"
-version = "0.8.3"
+version = "0.8.4"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,6 @@ Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 OceanBioME = "a49af516-9db8-4be4-be45-1dad61c5a376"
 Oceananigans = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
 Enzyme = "0.13, 0.14"

--- a/examples/export_model_setup.jl
+++ b/examples/export_model_setup.jl
@@ -1,8 +1,8 @@
 # # [Exporting a model setup] (@id export_model_setup_example)
 
-# This example shows how to save the inputs used to construct an Agate model.
+# This example shows how to save a resolved Agate model setup.
 # Saving the setup makes it easier to recreate the same model later, or to share
-# the model configuration with someone else.
+# the resolved model configuration with someone else.
 
 # ## Loading dependencies
 # The example uses Agate.jl to construct the model and OceanBioME.jl to provide a
@@ -20,8 +20,8 @@ nothing #hide
 
 # `NiPiZD.construct_with_manifest` accepts the same keywords as `NiPiZD.construct`.
 # In addition to the biogeochemistry object, it returns a setup record describing
-# the model recipe and constructor inputs. Agate stores this setup as a manifest,
-# which is a JSON-compatible dictionary.
+# the resolved biological configuration, including parameters and size structure.
+# Agate stores this setup as a JSON-compatible manifest.
 
 grid = BoxModelGrid()
 

--- a/src/Manifests/Manifests.jl
+++ b/src/Manifests/Manifests.jl
@@ -4,8 +4,6 @@ module Manifests
 using Dates
 using JSON
 
-import OceanBioME, Oceananigans
-
 include("serialization.jl")
 
 export export_manifest, construct_from_manifest
@@ -27,7 +25,7 @@ function required(x::AbstractDict, key, path)
     return x[key]
 end
 
-package_version(mod) = string(something(Base.pkgversion(mod), "unknown"))
+agate_version() = string(something(Base.pkgversion(parentmodule(@__MODULE__)), "unknown"))
 
 """
     export_manifest(path, setup) -> path
@@ -103,10 +101,8 @@ function default_model_manifest(family::Symbol, data; group_roles=nothing)
         "schema" => MODEL_SETUP_SCHEMA,
         "created_at" => string(now(UTC)),
         "agate" => Dict{String,Any}(
-            "version" => package_version(parentmodule(@__MODULE__)),
+            "version" => agate_version(),
             "julia_version" => string(VERSION),
-            "oceananigans_version" => package_version(Oceananigans),
-            "oceanbiome_version" => package_version(OceanBioME),
         ),
         "model" => Dict{String,Any}("family" => family_name),
         "kwargs" => kwargs,

--- a/src/Manifests/Manifests.jl
+++ b/src/Manifests/Manifests.jl
@@ -9,6 +9,8 @@ include("serialization.jl")
 export export_manifest, construct_from_manifest
 
 const MODEL_SETUP_SCHEMA = "agate.model_setup.v1"
+# schema/model/kwargs and family kwargs are required for replay; created_at and agate
+# are optional provenance when reading existing v1 files.
 const MODEL_SETUP_KEYS = ("schema", "created_at", "agate", "model", "kwargs")
 const MODEL_KEYS = ("family",)
 
@@ -134,30 +136,36 @@ function constructor_kwargs(setup::AbstractDict, family; grid=nothing, arch=noth
         required(kwargs, key, "Model setup kwargs")
     end
 
-    pairs = Pair{Symbol,Any}[]
+    kwarg_pairs = Pair{Symbol,Any}[]
     if family == "NiPiZD"
-        push!(pairs, :size_structure => named_size_structure_kwargs(kwargs["size_structure"]))
+        push!(
+            kwarg_pairs,
+            :size_structure => named_size_structure_kwargs(kwargs["size_structure"]),
+        )
     else
         for key in ("phyto_size_structure", "zoo_size_structure")
             value = kwargs[key]
             value isa AbstractVector ||
                 throw(ArgumentError("Model setup kwargs.$key must be an array."))
-            push!(pairs, Symbol(key) => setup_value(value))
+            push!(kwarg_pairs, Symbol(key) => setup_value(value))
         end
     end
 
     open_bottom = kwargs["open_bottom"]
     open_bottom isa Bool ||
         throw(ArgumentError("Model setup kwargs.open_bottom must be a boolean."))
-    push!(pairs, :open_bottom => open_bottom)
-    push!(pairs, :parameters => parameter_kwargs(kwargs["parameters"]))
-    push!(pairs, :sinking_tracers => sinking_tracers_kwargs(kwargs["sinking_tracers"]))
-    push!(pairs, :scalar_type => decode_scalar_type(kwargs["scalar_type"]))
+    push!(kwarg_pairs, :open_bottom => open_bottom)
+    push!(kwarg_pairs, :parameters => parameter_kwargs(kwargs["parameters"]))
+    push!(
+        kwarg_pairs,
+        :sinking_tracers => sinking_tracers_kwargs(kwargs["sinking_tracers"]),
+    )
+    push!(kwarg_pairs, :scalar_type => decode_scalar_type(kwargs["scalar_type"]))
 
-    !isnothing(grid) && push!(pairs, :grid => grid)
-    !isnothing(arch) && push!(pairs, :arch => arch)
+    !isnothing(grid) && push!(kwarg_pairs, :grid => grid)
+    !isnothing(arch) && push!(kwarg_pairs, :arch => arch)
 
-    return (; pairs...)
+    return (; kwarg_pairs...)
 end
 
 function parameter_kwargs(parameters)
@@ -211,16 +219,18 @@ function sinking_tracers_kwargs(sinking)
 end
 
 function parameter_value(value, name)
-    if value isa AbstractVector && all(row -> row isa AbstractVector, value)
-        rows = Any[row for row in value]
-        isempty(rows) && return Matrix{Any}(undef, 0, 0)
-        ncols = length(rows[1])
-        all(row -> length(row) == ncols, rows) || throw(
-            ArgumentError("Model setup parameter $(repr(name)) matrix must be rectangular."),
-        )
-        return [setup_value(rows[i][j]) for i in eachindex(rows), j in eachindex(rows[1])]
-    end
-    return setup_value(value)
+    (value isa AbstractVector && all(row -> row isa AbstractVector, value)) ||
+        return setup_value(value)
+    isempty(value) && throw(
+        ArgumentError(
+            "Model setup parameter $(repr(name)) is an ambiguous empty array in schema v1."
+        ),
+    )
+    ncols = length(first(value))
+    all(row -> length(row) == ncols, value) || throw(
+        ArgumentError("Model setup parameter $(repr(name)) matrix must be rectangular."),
+    )
+    return [setup_value(value[i][j]) for i in eachindex(value), j in 1:ncols]
 end
 
 setup_value(x) = x

--- a/src/Manifests/Manifests.jl
+++ b/src/Manifests/Manifests.jl
@@ -10,6 +10,21 @@ include("serialization.jl")
 export export_manifest, construct_from_manifest
 
 const MODEL_SETUP_SCHEMA = "agate.model_setup.v1"
+const MODEL_SETUP_KEYS = ("schema", "created_at", "agate", "model", "kwargs")
+const MODEL_KEYS = ("family",)
+
+function check_keys(x, allowed, path)
+    x isa AbstractDict || throw(ArgumentError("$path must be an object."))
+    for key in keys(x)
+        key in allowed || throw(ArgumentError("$path has unsupported field $(repr(key))."))
+    end
+    return x
+end
+
+function required(x::AbstractDict, key, path)
+    haskey(x, key) || throw(ArgumentError("$path is missing required field $(repr(key))."))
+    return x[key]
+end
 
 agate_project_root() = dirname(dirname(@__DIR__))
 agate_project_toml() = joinpath(agate_project_root(), "Project.toml")
@@ -44,7 +59,7 @@ Reconstruct an Agate biogeochemistry object from an exported model setup.
 """
 function construct_from_manifest(setup::AbstractDict; grid=nothing, arch=nothing)
     family = model_family(setup)
-    kwargs = constructor_kwargs(setup; grid, arch)
+    kwargs = constructor_kwargs(setup, family; grid, arch)
     models = getfield(parentmodule(@__MODULE__), :Models)
     return getfield(models, Symbol(family)).construct(; kwargs...)
 end
@@ -102,36 +117,49 @@ function default_model_manifest(family::Symbol, data; group_roles=nothing)
 end
 
 function model_family(setup::AbstractDict)
-    get(setup, "schema", nothing) == MODEL_SETUP_SCHEMA ||
-        throw(ArgumentError("Unsupported Agate model setup schema."))
+    check_keys(setup, MODEL_SETUP_KEYS, "Model setup")
+    schema = required(setup, "schema", "Model setup")
+    schema == MODEL_SETUP_SCHEMA || throw(
+        ArgumentError(
+            "Unsupported Agate model setup schema $(repr(schema)); expected $(repr(MODEL_SETUP_SCHEMA))."
+        ),
+    )
 
-    model = get(setup, "model", nothing)
-    model isa AbstractDict || throw(ArgumentError("Model setup is missing a model section."))
-
-    family = get(model, "family", nothing)
+    model = check_keys(required(setup, "model", "Model setup"), MODEL_KEYS, "Model setup model")
+    family = required(model, "family", "Model setup model")
     family in ("DARWIN", "NiPiZD") && return family
 
     throw(ArgumentError("Unsupported model family $(repr(family))."))
 end
 
-function constructor_kwargs(setup::AbstractDict; grid=nothing, arch=nothing)
-    kwargs = get(setup, "kwargs", nothing)
-    kwargs isa AbstractDict || throw(ArgumentError("Model setup is missing constructor kwargs."))
-
-    pairs = Pair{Symbol,Any}[]
-
-    haskey(kwargs, "size_structure") &&
-        push!(pairs, :size_structure => named_size_structure_kwargs(kwargs["size_structure"]))
-    for key in ("phyto_size_structure", "zoo_size_structure", "open_bottom")
-        haskey(kwargs, key) && push!(pairs, Symbol(key) => setup_value(kwargs[key]))
+function constructor_kwargs(setup::AbstractDict, family; grid=nothing, arch=nothing)
+    common = ("parameters", "sinking_tracers", "open_bottom", "scalar_type")
+    allowed = family == "NiPiZD" ? (common..., "size_structure") :
+        (common..., "phyto_size_structure", "zoo_size_structure")
+    kwargs = check_keys(required(setup, "kwargs", "Model setup"), allowed, "Model setup kwargs")
+    for key in allowed
+        required(kwargs, key, "Model setup kwargs")
     end
 
-    haskey(kwargs, "parameters") &&
-        push!(pairs, :parameters => parameter_kwargs(kwargs["parameters"]))
-    haskey(kwargs, "sinking_tracers") &&
-        push!(pairs, :sinking_tracers => sinking_tracers_kwargs(kwargs["sinking_tracers"]))
-    haskey(kwargs, "scalar_type") &&
-        push!(pairs, :scalar_type => decode_scalar_type(kwargs["scalar_type"]))
+    pairs = Pair{Symbol,Any}[]
+    if family == "NiPiZD"
+        push!(pairs, :size_structure => named_size_structure_kwargs(kwargs["size_structure"]))
+    else
+        for key in ("phyto_size_structure", "zoo_size_structure")
+            value = kwargs[key]
+            value isa AbstractVector ||
+                throw(ArgumentError("Model setup kwargs.$key must be an array."))
+            push!(pairs, Symbol(key) => setup_value(value))
+        end
+    end
+
+    open_bottom = kwargs["open_bottom"]
+    open_bottom isa Bool ||
+        throw(ArgumentError("Model setup kwargs.open_bottom must be a boolean."))
+    push!(pairs, :open_bottom => open_bottom)
+    push!(pairs, :parameters => parameter_kwargs(kwargs["parameters"]))
+    push!(pairs, :sinking_tracers => sinking_tracers_kwargs(kwargs["sinking_tracers"]))
+    push!(pairs, :scalar_type => decode_scalar_type(kwargs["scalar_type"]))
 
     !isnothing(grid) && push!(pairs, :grid => grid)
     !isnothing(arch) && push!(pairs, :arch => arch)
@@ -139,39 +167,64 @@ function constructor_kwargs(setup::AbstractDict; grid=nothing, arch=nothing)
     return (; pairs...)
 end
 
-function parameter_kwargs(parameters::AbstractDict)
-    return (; (Symbol(k) => parameter_value(v) for (k, v) in pairs(parameters))...)
+function parameter_kwargs(parameters)
+    parameters isa AbstractDict ||
+        throw(ArgumentError("Model setup kwargs.parameters must be an object."))
+    return (; (Symbol(k) => parameter_value(v, k) for (k, v) in pairs(parameters))...)
 end
 
-function named_size_structure_kwargs(size_structure::AbstractDict)
+function named_size_structure_kwargs(size_structure)
+    path = "Model setup kwargs.size_structure"
+    check_keys(size_structure, ("phytoplankton", "zooplankton"), path)
     return (;
         phytoplankton=named_role_size_structure(size_structure, "phytoplankton"),
         zooplankton=named_role_size_structure(size_structure, "zooplankton"),
     )
 end
 
-function named_size_structure_kwargs(size_structure)
-    throw(ArgumentError("Model setup size_structure must be an object."))
-end
-
 function named_role_size_structure(size_structure::AbstractDict, role::AbstractString)
-    groups = get(size_structure, role, nothing)
-    groups isa AbstractVector ||
-        throw(ArgumentError("Model setup size_structure.$role must be an array."))
-    return (;
-        (Symbol(group["name"]) => setup_value(group["diameters"]) for group in groups)...
-    )
+    path = "Model setup kwargs.size_structure.$role"
+    groups = required(size_structure, role, "Model setup kwargs.size_structure")
+    groups isa AbstractVector || throw(ArgumentError("$path must be an array."))
+
+    entries = Pair{Symbol,Any}[]
+    for (i, group) in pairs(groups)
+        group_path = "$path[$i]"
+        group = check_keys(group, ("name", "diameters"), group_path)
+        name = required(group, "name", group_path)
+        name isa AbstractString || throw(ArgumentError("$group_path.name must be a string."))
+        diameters = required(group, "diameters", group_path)
+        diameters isa AbstractVector ||
+            throw(ArgumentError("$group_path.diameters must be an array."))
+        push!(entries, Symbol(name) => setup_value(diameters))
+    end
+    return (; entries...)
 end
 
 function sinking_tracers_kwargs(sinking)
     isnothing(sinking) && return nothing
-    return (; (Symbol(item["name"]) => setup_value(item["value"]) for item in sinking)...)
+    path = "Model setup kwargs.sinking_tracers"
+    sinking isa AbstractVector || throw(ArgumentError("$path must be an array or null."))
+
+    entries = Pair{Symbol,Any}[]
+    for (i, item) in pairs(sinking)
+        item_path = "$path[$i]"
+        item = check_keys(item, ("name", "value"), item_path)
+        name = required(item, "name", item_path)
+        name isa AbstractString || throw(ArgumentError("$item_path.name must be a string."))
+        push!(entries, Symbol(name) => setup_value(required(item, "value", item_path)))
+    end
+    return (; entries...)
 end
 
-function parameter_value(value)
+function parameter_value(value, name)
     if value isa AbstractVector && all(row -> row isa AbstractVector, value)
         rows = Any[row for row in value]
         isempty(rows) && return Matrix{Any}(undef, 0, 0)
+        ncols = length(rows[1])
+        all(row -> length(row) == ncols, rows) || throw(
+            ArgumentError("Model setup parameter $(repr(name)) matrix must be rectangular."),
+        )
         return [setup_value(rows[i][j]) for i in eachindex(rows), j in eachindex(rows[1])]
     end
     return setup_value(value)

--- a/src/Manifests/Manifests.jl
+++ b/src/Manifests/Manifests.jl
@@ -3,7 +3,8 @@ module Manifests
 
 using Dates
 using JSON
-using TOML
+
+import OceanBioME, Oceananigans
 
 include("serialization.jl")
 
@@ -26,13 +27,7 @@ function required(x::AbstractDict, key, path)
     return x[key]
 end
 
-agate_project_root() = dirname(dirname(@__DIR__))
-agate_project_toml() = joinpath(agate_project_root(), "Project.toml")
-
-function agate_version()
-    project = TOML.parsefile(agate_project_toml())
-    return string(project["version"])
-end
+package_version(mod) = string(something(Base.pkgversion(mod), "unknown"))
 
 """
     export_manifest(path, setup) -> path
@@ -108,8 +103,10 @@ function default_model_manifest(family::Symbol, data; group_roles=nothing)
         "schema" => MODEL_SETUP_SCHEMA,
         "created_at" => string(now(UTC)),
         "agate" => Dict{String,Any}(
-            "version" => agate_version(),
+            "version" => package_version(parentmodule(@__MODULE__)),
             "julia_version" => string(VERSION),
+            "oceananigans_version" => package_version(Oceananigans),
+            "oceanbiome_version" => package_version(OceanBioME),
         ),
         "model" => Dict{String,Any}("family" => family_name),
         "kwargs" => kwargs,

--- a/src/Manifests/Manifests.jl
+++ b/src/Manifests/Manifests.jl
@@ -178,6 +178,12 @@ function parameter_value(value)
 end
 
 setup_value(x) = x
+function setup_value(x::AbstractString)
+    x == "NaN" && return NaN
+    x == "Inf" && return Inf
+    x == "-Inf" && return -Inf
+    return x
+end
 setup_value(x::AbstractVector) = Any[setup_value(v) for v in x]
 setup_value(x::AbstractDict) = (; (Symbol(k) => setup_value(v) for (k, v) in pairs(x))...)
 

--- a/src/Manifests/serialization.jl
+++ b/src/Manifests/serialization.jl
@@ -5,8 +5,6 @@ function manifest_value(x, name=nothing)
         return x
     elseif x isa AbstractFloat
         return isfinite(x) ? x : string(x)
-    elseif x isa Symbol
-        return string(x)
     elseif x isa NamedTuple
         return Dict{String,Any}(string(k) => manifest_value(v, k) for (k, v) in pairs(x))
     elseif x isa AbstractDict

--- a/src/Models/DARWIN/interface.jl
+++ b/src/Models/DARWIN/interface.jl
@@ -175,7 +175,7 @@ end
 """
     construct_with_manifest(; kw...) -> bgc, manifest
 
-Construct a model instance and return it with a JSON-compatible model setup manifest.
+Construct a model instance and return it with a JSON-compatible manifest of the resolved model setup.
 """
 function construct_with_manifest(; kwargs...)
     inputs = _construction_inputs(; kwargs...)

--- a/src/Models/NiPiZD/interface.jl
+++ b/src/Models/NiPiZD/interface.jl
@@ -186,7 +186,7 @@ end
 """
     construct_with_manifest(; kw...) -> bgc, manifest
 
-Construct a model instance and return it with a JSON-compatible model setup manifest.
+Construct a model instance and return it with a JSON-compatible manifest of the resolved model setup.
 Groups are recorded in role/group order with their resolved class diameters.
 """
 function construct_with_manifest(; kwargs...)

--- a/test/test_model_setup_manifest.jl
+++ b/test/test_model_setup_manifest.jl
@@ -15,10 +15,12 @@ function test_exact_parameters(actual, expected)
         expected_value = getproperty(expected, key)
         if key === :interactions
             for field in fieldnames(typeof(expected_value))
-                @test getfield(actual_value, field) == getfield(expected_value, field)
+                @test isequal(
+                    getfield(actual_value, field), getfield(expected_value, field)
+                )
             end
         else
-            @test actual_value == expected_value
+            @test isequal(actual_value, expected_value)
         end
     end
 end
@@ -85,12 +87,7 @@ end
     reconstructed = construct_from_manifest(path)
     test_reconstructed_model(reconstructed, bgc)
 
-    for key in (:detritus_remineralization, :linear_mortality, :palatability_matrix)
-        actual = getproperty(reconstructed.parameters, key)
-        expected = getproperty(bgc.parameters, key)
-        @test typeof(actual) == typeof(expected)
-        @test isequal(actual, expected)
-    end
+    test_exact_parameters(reconstructed.parameters, bgc.parameters)
 end
 
 @testset "NiPiZD named model setup round trip" begin
@@ -136,6 +133,10 @@ end
           Agate.Introspection.plankton_diameters(bgc)
 end
 
+@testset "Model setup serialization validation" begin
+    @test_throws ArgumentError Agate.Manifests.Serialization.manifest_value(:unsupported)
+end
+
 @testset "Model setup reader validation" begin
     _, setup = Agate.Models.NiPiZD.construct_with_manifest(;
         palatability_matrix=[0.8 0.2; 0.3 0.7]
@@ -150,7 +151,7 @@ end
     test_manifest_argument_error(setup, "Model setup kwargs has unsupported field") do invalid
         invalid["kwargs"]["unexpected"] = true
     end
-    test_manifest_argument_error(setup, "scalar_type") do invalid
+    test_manifest_argument_error(setup, "missing required field \"scalar_type\"") do invalid
         delete!(invalid["kwargs"], "scalar_type")
     end
     test_manifest_argument_error(setup, "parameters must be an object") do invalid
@@ -161,6 +162,9 @@ end
     end
     test_manifest_argument_error(setup, "sinking_tracers[1]") do invalid
         invalid["kwargs"]["sinking_tracers"] = [Dict("name" => "D")]
+    end
+    test_manifest_argument_error(setup, "ambiguous empty array") do invalid
+        invalid["kwargs"]["parameters"]["palatability_matrix"] = Any[]
     end
     test_manifest_argument_error(setup, "matrix must be rectangular") do invalid
         invalid["kwargs"]["parameters"]["palatability_matrix"] = [[1.0, 2.0], [3.0]]

--- a/test/test_model_setup_manifest.jl
+++ b/test/test_model_setup_manifest.jl
@@ -21,7 +21,7 @@ function test_manifest_argument_error(edit, setup, message)
     err isa ArgumentError && @test occursin(message, sprint(showerror, err))
 end
 
-@testset "NiPiZD model setup export and import" begin
+@testset "NiPiZD Float32 model setup round trip" begin
     grid = BoxModelGrid()
     palatability_matrix = Float32[0.8 0.2; 0.3 0.7]
     sinking_tracers = (P_1=0.125f0 / day, D=1.5f0 / day)
@@ -40,16 +40,17 @@ end
     reconstructed = construct_from_manifest(path; grid)
     test_reconstructed_model(reconstructed, bgc)
 
-    @test reconstructed.parameters.palatability_matrix ≈ palatability_matrix
+    @test typeof(reconstructed.parameters) == typeof(bgc.parameters)
+    @test reconstructed.parameters == bgc.parameters
     @test !isnothing(reconstructed.sinking_velocities)
 
     reconstructed_P_1 = biogeochemical_drift_velocity(reconstructed, Val(:P_1)).w.data[1, 1, 1]
     reconstructed_D = biogeochemical_drift_velocity(reconstructed, Val(:D)).w.data[1, 1, 1]
 
-    @test reconstructed_P_1 ≈ biogeochemical_drift_velocity(bgc, Val(:P_1)).w.data[1, 1, 1]
-    @test reconstructed_D ≈ biogeochemical_drift_velocity(bgc, Val(:D)).w.data[1, 1, 1]
-    @test reconstructed_P_1 ≈ -sinking_tracers.P_1
-    @test reconstructed_D ≈ -sinking_tracers.D
+    @test reconstructed_P_1 == biogeochemical_drift_velocity(bgc, Val(:P_1)).w.data[1, 1, 1]
+    @test reconstructed_D == biogeochemical_drift_velocity(bgc, Val(:D)).w.data[1, 1, 1]
+    @test reconstructed_P_1 == -sinking_tracers.P_1
+    @test reconstructed_D == -sinking_tracers.D
 end
 
 @testset "NiPiZD non-finite model setup round trip" begin
@@ -99,12 +100,8 @@ end
     @test Agate.Introspection.plankton_diameters(reconstructed) ==
           Agate.Introspection.plankton_diameters(bgc)
 
-    active(model) = Agate.Runtime.active_parameters(model;
-        maximum_growth_rate=(:diat_2,),
-        interactions=(; palatability=((:microzoo_1, :diat_1),)),
-    )
-    @test active(reconstructed).labels == active(bgc).labels
-    @test active(reconstructed).values == active(bgc).values
+    @test typeof(reconstructed.parameters) == typeof(bgc.parameters)
+    @test reconstructed.parameters == bgc.parameters
 end
 
 @testset "DARWIN model setup import" begin
@@ -119,6 +116,10 @@ end
 
     reconstructed = construct_from_manifest(setup; grid)
     test_reconstructed_model(reconstructed, bgc)
+    @test typeof(reconstructed.parameters) == typeof(bgc.parameters)
+    @test reconstructed.parameters == bgc.parameters
+    @test Agate.Introspection.plankton_diameters(reconstructed) ==
+          Agate.Introspection.plankton_diameters(bgc)
 end
 
 @testset "Model setup reader validation" begin

--- a/test/test_model_setup_manifest.jl
+++ b/test/test_model_setup_manifest.jl
@@ -1,3 +1,5 @@
+import OceanBioME, Oceananigans
+
 using Oceananigans.Units: day
 using OceanBioME: BoxModelGrid
 using Oceananigans.Biogeochemistry: biogeochemical_drift_velocity, required_biogeochemical_tracers
@@ -48,6 +50,8 @@ end
         palatability_matrix,
         sinking_tracers,
     )
+
+    @test setup["agate"]["version"] == string(Base.pkgversion(Agate))
 
     path = tempname() * ".json"
     @test export_manifest(path, setup) == path

--- a/test/test_model_setup_manifest.jl
+++ b/test/test_model_setup_manifest.jl
@@ -8,6 +8,19 @@ function test_reconstructed_model(reconstructed, expected)
     @test required_biogeochemical_tracers(reconstructed) == required_biogeochemical_tracers(expected)
 end
 
+function test_manifest_argument_error(edit, setup, message)
+    invalid = deepcopy(setup)
+    edit(invalid)
+    err = try
+        construct_from_manifest(invalid)
+        nothing
+    catch err
+        err
+    end
+    @test err isa ArgumentError
+    err isa ArgumentError && @test occursin(message, sprint(showerror, err))
+end
+
 @testset "NiPiZD model setup export and import" begin
     grid = BoxModelGrid()
     palatability_matrix = Float32[0.8 0.2; 0.3 0.7]
@@ -106,4 +119,35 @@ end
 
     reconstructed = construct_from_manifest(setup; grid)
     test_reconstructed_model(reconstructed, bgc)
+end
+
+@testset "Model setup reader validation" begin
+    _, setup = Agate.Models.NiPiZD.construct_with_manifest(;
+        palatability_matrix=[0.8 0.2; 0.3 0.7]
+    )
+
+    test_manifest_argument_error(setup, "Model setup has unsupported field") do invalid
+        invalid["unexpected"] = true
+    end
+    test_manifest_argument_error(setup, "agate.model_setup.v2") do invalid
+        invalid["schema"] = "agate.model_setup.v2"
+    end
+    test_manifest_argument_error(setup, "Model setup kwargs has unsupported field") do invalid
+        invalid["kwargs"]["unexpected"] = true
+    end
+    test_manifest_argument_error(setup, "scalar_type") do invalid
+        delete!(invalid["kwargs"], "scalar_type")
+    end
+    test_manifest_argument_error(setup, "parameters must be an object") do invalid
+        invalid["kwargs"]["parameters"] = Any[]
+    end
+    test_manifest_argument_error(setup, "size_structure.phytoplankton[1]") do invalid
+        invalid["kwargs"]["size_structure"]["phytoplankton"][1]["unexpected"] = true
+    end
+    test_manifest_argument_error(setup, "sinking_tracers[1]") do invalid
+        invalid["kwargs"]["sinking_tracers"] = [Dict("name" => "D")]
+    end
+    test_manifest_argument_error(setup, "matrix must be rectangular") do invalid
+        invalid["kwargs"]["parameters"]["palatability_matrix"] = [[1.0, 2.0], [3.0]]
+    end
 end

--- a/test/test_model_setup_manifest.jl
+++ b/test/test_model_setup_manifest.jl
@@ -39,6 +39,30 @@ end
     @test reconstructed_D ≈ -sinking_tracers.D
 end
 
+@testset "NiPiZD non-finite model setup round trip" begin
+    bgc, setup = Agate.Models.NiPiZD.construct_with_manifest(
+        ;
+        scalar_type=Float32,
+        parameters=(;
+            detritus_remineralization=Float32(NaN),
+            linear_mortality=Float32[Inf, -Inf, 0, 0],
+        ),
+        palatability_matrix=Float32[NaN Inf; -Inf 0.5],
+    )
+
+    path = tempname() * ".json"
+    export_manifest(path, setup)
+    reconstructed = construct_from_manifest(path)
+    test_reconstructed_model(reconstructed, bgc)
+
+    for key in (:detritus_remineralization, :linear_mortality, :palatability_matrix)
+        actual = getproperty(reconstructed.parameters, key)
+        expected = getproperty(bgc.parameters, key)
+        @test typeof(actual) == typeof(expected)
+        @test isequal(actual, expected)
+    end
+end
+
 @testset "NiPiZD named model setup round trip" begin
     size_structure = (;
         phytoplankton=(diat=[2.0, 5.0], dino=[10.0]),

--- a/test/test_model_setup_manifest.jl
+++ b/test/test_model_setup_manifest.jl
@@ -1,5 +1,3 @@
-import OceanBioME, Oceananigans
-
 using Oceananigans.Units: day
 using OceanBioME: BoxModelGrid
 using Oceananigans.Biogeochemistry: biogeochemical_drift_velocity, required_biogeochemical_tracers

--- a/test/test_model_setup_manifest.jl
+++ b/test/test_model_setup_manifest.jl
@@ -8,6 +8,21 @@ function test_reconstructed_model(reconstructed, expected)
     @test required_biogeochemical_tracers(reconstructed) == required_biogeochemical_tracers(expected)
 end
 
+function test_exact_parameters(actual, expected)
+    @test typeof(actual) == typeof(expected)
+    for key in keys(expected)
+        actual_value = getproperty(actual, key)
+        expected_value = getproperty(expected, key)
+        if key === :interactions
+            for field in fieldnames(typeof(expected_value))
+                @test getfield(actual_value, field) == getfield(expected_value, field)
+            end
+        else
+            @test actual_value == expected_value
+        end
+    end
+end
+
 function test_manifest_argument_error(edit, setup, message)
     invalid = deepcopy(setup)
     edit(invalid)
@@ -40,8 +55,7 @@ end
     reconstructed = construct_from_manifest(path; grid)
     test_reconstructed_model(reconstructed, bgc)
 
-    @test typeof(reconstructed.parameters) == typeof(bgc.parameters)
-    @test reconstructed.parameters == bgc.parameters
+    test_exact_parameters(reconstructed.parameters, bgc.parameters)
     @test !isnothing(reconstructed.sinking_velocities)
 
     reconstructed_P_1 = biogeochemical_drift_velocity(reconstructed, Val(:P_1)).w.data[1, 1, 1]
@@ -100,8 +114,7 @@ end
     @test Agate.Introspection.plankton_diameters(reconstructed) ==
           Agate.Introspection.plankton_diameters(bgc)
 
-    @test typeof(reconstructed.parameters) == typeof(bgc.parameters)
-    @test reconstructed.parameters == bgc.parameters
+    test_exact_parameters(reconstructed.parameters, bgc.parameters)
 end
 
 @testset "DARWIN model setup import" begin
@@ -116,8 +129,7 @@ end
 
     reconstructed = construct_from_manifest(setup; grid)
     test_reconstructed_model(reconstructed, bgc)
-    @test typeof(reconstructed.parameters) == typeof(bgc.parameters)
-    @test reconstructed.parameters == bgc.parameters
+    test_exact_parameters(reconstructed.parameters, bgc.parameters)
     @test Agate.Introspection.plankton_diameters(reconstructed) ==
           Agate.Introspection.plankton_diameters(bgc)
 end


### PR DESCRIPTION
- Improves agate.model_setup.v1 replay with symmetric support for NaN, Inf, and -Inf.

- Improves manifest validation with clear errors for unsupported fields, missing required replay fields, unsupported schema versions, malformed structures, non-rectangular parameter matrices, and ambiguous empty parameter arrays.

- Improves serialization discipline by rejecting unsupported Symbol-valued parameter data rather than silently converting it to strings.

- Improves exact replay coverage for Float32 parameters, matrices, nested parameter state, interaction matrices, sinking velocities, and size structures.

- Improves Agate version provenance using Base.pkgversion.

- Refactors model setup documentation to describe manifests as resolved model setups.

- Removes the direct TOML dependency.