### PR TITLE
Replace smooth Liebig nutrient limitation with Frank t norm

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Agate"
 uuid = "41889b7c-c35c-4f16-abd7-94b299d9fd29"
-version = "0.8.4"
+version = "0.9.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -15,14 +15,9 @@ Private = false
 
 ## Nutrients
 
-```@docs
-Agate.Library.Nutrients.LiebigMinimum
-Agate.Library.Nutrients.FrankMinimum
-```
-
 ```@autodocs
 Modules=[Agate.Library.Nutrients]
-Private = false        
+Private = false
 ```
 
 ## Photosynthesis

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -15,6 +15,11 @@ Private = false
 
 ## Nutrients
 
+```@docs
+Agate.Library.Nutrients.LiebigMinimum
+Agate.Library.Nutrients.FrankMinimum
+```
+
 ```@autodocs
 Modules=[Agate.Library.Nutrients]
 Private = false        

--- a/src/Library/nutrients.jl
+++ b/src/Library/nutrients.jl
@@ -106,12 +106,23 @@ factors in ``[0, 1]``.
 
 Finite `sharpness` provides a smooth transition through nutrient co-limitation
 for automatic differentiation; `LiebigMinimum` remains the exact hard minimum.
+The default `sharpness = 50` keeps the transition localized while retaining a
+smooth derivative crossover. Finite sharpness can underestimate the hard minimum
+when several small limitation factors are similar; increasing `sharpness` reduces
+that discrepancy while narrowing the smooth transition.
+
+!!! warning "Domain"
+    `FrankMinimum` is defined for normalized limitation factors in ``[0, 1]``.
+    Inputs outside this interval can violate the minimum-like bounds or produce
+    non-finite values.
 """
 struct FrankMinimum{S}
     sharpness::S
 end
 
-@inline FrankMinimum() = FrankMinimum(50)
+const DEFAULT_FRANK_SHARPNESS = 50
+
+@inline FrankMinimum() = FrankMinimum(DEFAULT_FRANK_SHARPNESS)
 
 @inline function (f::FrankMinimum)(a, b)
     s = oftype(one(a + b), f.sharpness)
@@ -164,13 +175,19 @@ This is an explicit alias around `LiebigMinimum()` for clearer model code.
     frank_minimum(a, b, rest...; sharpness = 50)
     frank_minimum(values::NTuple; sharpness = 50)
 
-Return the differentiable Frank-family minimum of the supplied limitation
-factors. Positive `sharpness` values increasingly approximate `liebig_minimum`.
+Return the differentiable Frank-family minimum of normalized limitation
+factors in `[0, 1]`. Positive `sharpness` values increasingly approximate
+`liebig_minimum`. Finite sharpness smooths co-limitation but can underestimate
+the hard minimum when several small limitation factors are similar.
 """
-@inline frank_minimum(a, b; sharpness=50) = FrankMinimum(sharpness)(a, b)
+@inline frank_minimum(a, b; sharpness=DEFAULT_FRANK_SHARPNESS) =
+    FrankMinimum(sharpness)(a, b)
 
-@inline frank_minimum(a, b, c, rest...; sharpness=50) = FrankMinimum(sharpness)(a, b, c, rest...)
+@inline frank_minimum(a, b, c, rest...; sharpness=DEFAULT_FRANK_SHARPNESS) =
+    FrankMinimum(sharpness)(a, b, c, rest...)
 
-@inline frank_minimum(values::Tuple{Vararg{Any,N}}; sharpness=50) where N = FrankMinimum(sharpness)(values)
+@inline frank_minimum(
+    values::Tuple{Vararg{Any,N}}; sharpness=DEFAULT_FRANK_SHARPNESS
+) where N = FrankMinimum(sharpness)(values)
 
 end # module

--- a/src/Library/nutrients.jl
+++ b/src/Library/nutrients.jl
@@ -2,7 +2,7 @@
 
 module Nutrients
 
-export monod_limitation, liebig_minimum, frank_minimum
+export monod_limitation, liebig_minimum, frank_tnorm
 
 """
     MonodLimitation(K)
@@ -81,28 +81,29 @@ end
     return m
 end
 
-raw"""
-    FrankMinimum()
-    FrankMinimum(sharpness)
+"""
+    FrankTNorm()
+    FrankTNorm(sharpness)
 
-Differentiable Frank-family approximation to Liebig's minimum on limitation
-factors in ``[0, 1]``.
+Differentiable Frank t-norm approximation to Liebig's minimum on limitation
+factors in `[0, 1]`.
 
 !!! formulation
-    For two limitation factors ``a`` and ``b``, let ``q = \exp(-s)`` where
-    ``s`` is `sharpness`. The Frank minimum is
+    For two limitation factors `a` and `b`, let `q = exp(-s)`, where `s` is
+    `sharpness`. The Frank t-norm is
 
-    ```math
-    F_s(a, b) = \log_q\left(1 + \frac{(q^a - 1)(q^b - 1)}{q - 1}\right).
+    ```text
+    q = exp(-s)
+    F(a, b) = log(1 + ((q^a - 1) * (q^b - 1)) / (q - 1)) / log(q)
     ```
 
     Positive `sharpness` values give the minimum-like branch of the Frank
     family, with larger values approaching `min(a, b)`. The implementation uses
     an equivalent shifted form for numerical stability.
 
-    ``1`` is the neutral element, so ``F_s(a, 1) = a``. ``0`` is absorbing, so
-    ``F_s(a, 0) = 0``. For more than two factors the associative binary operator
-    is applied successively.
+    `1` is the neutral element, so `F(a, 1) = a`. `0` is absorbing, so
+    `F(a, 0) = 0`. For more than two factors the associative binary operator is
+    applied successively.
 
 Finite `sharpness` provides a smooth transition through nutrient co-limitation
 for automatic differentiation; `LiebigMinimum` remains the exact hard minimum.
@@ -112,19 +113,19 @@ when several small limitation factors are similar; increasing `sharpness` reduce
 that discrepancy while narrowing the smooth transition.
 
 !!! warning "Domain"
-    `FrankMinimum` is defined for normalized limitation factors in ``[0, 1]``.
+    `FrankTNorm` is defined for normalized limitation factors in `[0, 1]`.
     Inputs outside this interval can violate the minimum-like bounds or produce
     non-finite values.
 """
-struct FrankMinimum{S}
+struct FrankTNorm{S}
     sharpness::S
 end
 
 const DEFAULT_FRANK_SHARPNESS = 50
 
-@inline FrankMinimum() = FrankMinimum(DEFAULT_FRANK_SHARPNESS)
+@inline FrankTNorm() = FrankTNorm(DEFAULT_FRANK_SHARPNESS)
 
-@inline function (f::FrankMinimum)(a, b)
+@inline function (f::FrankTNorm)(a, b)
     s = oftype(one(a + b), f.sharpness)
     a_is_min = a < b
     m = ifelse(a_is_min, a, b)
@@ -138,11 +139,11 @@ const DEFAULT_FRANK_SHARPNESS = 50
     return ifelse(isnan(a) | isnan(b), a + b, result)
 end
 
-@inline function (f::FrankMinimum)(a, b, c, rest...)
+@inline function (f::FrankTNorm)(a, b, c, rest...)
     return f((a, b, c, rest...))
 end
 
-@inline function (f::FrankMinimum)(values::Tuple{Vararg{Any,N}}) where N
+@inline function (f::FrankTNorm)(values::Tuple{Vararg{Any,N}}) where N
     result = values[1]
     @inbounds for i in 2:N
         result = f(result, values[i])
@@ -172,22 +173,48 @@ This is an explicit alias around `LiebigMinimum()` for clearer model code.
 @inline liebig_minimum(values::Tuple{Vararg{Any,N}}) where N = LiebigMinimum()(values)
 
 """
-    frank_minimum(a, b, rest...; sharpness = 50)
-    frank_minimum(values::NTuple; sharpness = 50)
+    frank_tnorm(a, b, rest...; sharpness = 50)
+    frank_tnorm(values::NTuple; sharpness = 50)
 
-Return the differentiable Frank-family minimum of normalized limitation
-factors in `[0, 1]`. Positive `sharpness` values increasingly approximate
-`liebig_minimum`. Finite sharpness smooths co-limitation but can underestimate
-the hard minimum when several small limitation factors are similar.
+Return the differentiable Frank t-norm approximation to Liebig's minimum for
+normalized limitation factors in `[0, 1]`.
+
+For two limitation factors `a` and `b`, let `q = exp(-s)`, where `s` is
+`sharpness`. The Frank t-norm is
+
+```text
+q = exp(-s)
+F(a, b) = log(1 + ((q^a - 1) * (q^b - 1)) / (q - 1)) / log(q)
+```
+
+Positive `sharpness` values give the minimum-like branch of the Frank family,
+with larger values approaching `liebig_minimum(a, b)`. The implementation uses
+an equivalent shifted form for numerical stability. For more than two factors,
+the associative binary operator is applied successively.
+
+`1` is the neutral element and `0` is absorbing. Finite sharpness provides a
+smooth derivative transition through nutrient co-limitation for automatic
+differentiation. The default `sharpness = 50` keeps that transition localized
+while retaining a smooth crossover. Finite sharpness can underestimate the hard
+minimum when several small limitation factors are similar; increasing
+`sharpness` reduces that discrepancy while narrowing the smooth transition.
+
+!!! warning "Domain"
+    The Frank t-norm is defined for normalized limitation factors in `[0, 1]`.
+    Inputs outside this interval can violate the minimum-like bounds or produce
+    non-finite values.
+
+The callable `FrankTNorm(sharpness)` functor provides the same operation for
+lower-level tendency configuration.
 """
-@inline frank_minimum(a, b; sharpness=DEFAULT_FRANK_SHARPNESS) =
-    FrankMinimum(sharpness)(a, b)
+@inline frank_tnorm(a, b; sharpness=DEFAULT_FRANK_SHARPNESS) =
+    FrankTNorm(sharpness)(a, b)
 
-@inline frank_minimum(a, b, c, rest...; sharpness=DEFAULT_FRANK_SHARPNESS) =
-    FrankMinimum(sharpness)(a, b, c, rest...)
+@inline frank_tnorm(a, b, c, rest...; sharpness=DEFAULT_FRANK_SHARPNESS) =
+    FrankTNorm(sharpness)(a, b, c, rest...)
 
-@inline frank_minimum(
+@inline frank_tnorm(
     values::Tuple{Vararg{Any,N}}; sharpness=DEFAULT_FRANK_SHARPNESS
-) where N = FrankMinimum(sharpness)(values)
+) where N = FrankTNorm(sharpness)(values)
 
 end # module

--- a/src/Library/nutrients.jl
+++ b/src/Library/nutrients.jl
@@ -2,7 +2,7 @@
 
 module Nutrients
 
-export monod_limitation, liebig_minimum, smooth_liebig_minimum
+export monod_limitation, liebig_minimum, frank_minimum
 
 """
     MonodLimitation(K)
@@ -82,48 +82,61 @@ end
 end
 
 raw"""
-    SmoothLiebigMinimum(sharpness)
+    FrankMinimum()
+    FrankMinimum(sharpness)
 
-Smooth approximation to Liebig's law of the minimum.
+Differentiable Frank-family approximation to Liebig's minimum on limitation
+factors in ``[0, 1]``.
 
 !!! formulation
+    For two limitation factors ``a`` and ``b``, let ``q = \exp(-s)`` where
+    ``s`` is `sharpness`. The Frank minimum is
+
     ```math
-    -\frac{1}{s}\log\sum_i \exp(-s x_i)
+    F_s(a, b) = \log_q\left(1 + \frac{(q^a - 1)(q^b - 1)}{q - 1}\right).
     ```
 
-    where ``s`` is `sharpness`. Larger `sharpness` values more closely
-    approximate the hard minimum. The implementation uses a shifted log-sum-exp
-    form for numerical stability.
+    Positive `sharpness` values give the minimum-like branch of the Frank
+    family, with larger values approaching `min(a, b)`. The implementation uses
+    an equivalent shifted form for numerical stability.
+
+    ``1`` is the neutral element, so ``F_s(a, 1) = a``. ``0`` is absorbing, so
+    ``F_s(a, 0) = 0``. For more than two factors the associative binary operator
+    is applied successively.
+
+Finite `sharpness` provides a smooth transition through nutrient co-limitation
+for automatic differentiation; `LiebigMinimum` remains the exact hard minimum.
 """
-struct SmoothLiebigMinimum{S}
+struct FrankMinimum{S}
     sharpness::S
 end
 
-@inline SmoothLiebigMinimum() = SmoothLiebigMinimum(50)
+@inline FrankMinimum() = FrankMinimum(50)
 
-@inline function (l::SmoothLiebigMinimum)(a, b)
-    s = l.sharpness
-    m = ifelse(a < b, a, b)
-    return m - log(exp(-s * (a - m)) + exp(-s * (b - m))) / s
+@inline function (f::FrankMinimum)(a, b)
+    s = oftype(one(a + b), f.sharpness)
+    a_is_min = a < b
+    m = ifelse(a_is_min, a, b)
+    M = ifelse(a_is_min, b, a)
+    one_m = one(m)
+
+    numerator = one_m + exp(-s * (M - m)) - exp(-s * M) - exp(-s * (one_m - m))
+    denominator = one_m - exp(-s)
+    result = m - log(numerator / denominator) / s
+
+    return ifelse(isnan(a) | isnan(b), a + b, result)
 end
 
-@inline function (l::SmoothLiebigMinimum)(a, b, c, rest...)
-    return l((a, b, c, rest...))
+@inline function (f::FrankMinimum)(a, b, c, rest...)
+    return f((a, b, c, rest...))
 end
 
-@inline function (l::SmoothLiebigMinimum)(values::Tuple{Vararg{Any,N}}) where N
-    s = l.sharpness
-    m = values[1]
+@inline function (f::FrankMinimum)(values::Tuple{Vararg{Any,N}}) where N
+    result = values[1]
     @inbounds for i in 2:N
-        m = ifelse(values[i] < m, values[i], m)
+        result = f(result, values[i])
     end
-
-    total = zero(m)
-    @inbounds for i in 1:N
-        total += exp(-s * (values[i] - m))
-    end
-
-    return m - log(total) / s
+    return result
 end
 
 """
@@ -148,16 +161,16 @@ This is an explicit alias around `LiebigMinimum()` for clearer model code.
 @inline liebig_minimum(values::Tuple{Vararg{Any,N}}) where N = LiebigMinimum()(values)
 
 """
-    smooth_liebig_minimum(a, b, rest...; sharpness = 50)
-    smooth_liebig_minimum(values::NTuple; sharpness = 50)
+    frank_minimum(a, b, rest...; sharpness = 50)
+    frank_minimum(values::NTuple; sharpness = 50)
 
-Return a smooth approximation to the minimum value among the given limitation
-factors. Larger `sharpness` values approach `liebig_minimum`.
+Return the differentiable Frank-family minimum of the supplied limitation
+factors. Positive `sharpness` values increasingly approximate `liebig_minimum`.
 """
-@inline smooth_liebig_minimum(a, b; sharpness=50) = SmoothLiebigMinimum(sharpness)(a, b)
+@inline frank_minimum(a, b; sharpness=50) = FrankMinimum(sharpness)(a, b)
 
-@inline smooth_liebig_minimum(a, b, c, rest...; sharpness=50) = SmoothLiebigMinimum(sharpness)(a, b, c, rest...)
+@inline frank_minimum(a, b, c, rest...; sharpness=50) = FrankMinimum(sharpness)(a, b, c, rest...)
 
-@inline smooth_liebig_minimum(values::Tuple{Vararg{Any,N}}; sharpness=50) where N = SmoothLiebigMinimum(sharpness)(values)
+@inline frank_minimum(values::Tuple{Vararg{Any,N}}; sharpness=50) where N = FrankMinimum(sharpness)(values)
 
 end # module

--- a/src/Library/photosynthesis.jl
+++ b/src/Library/photosynthesis.jl
@@ -2,7 +2,7 @@
 
 module Photosynthesis
 
-using ..Nutrients: MonodLimitation, LiebigMinimum, FrankMinimum
+using ..Nutrients: MonodLimitation, LiebigMinimum, FrankMinimum, DEFAULT_FRANK_SHARPNESS
 
 export smith_light_limitation,
     geider_light_limitation,
@@ -163,11 +163,11 @@ end
 
 Compute a differentiable Frank minimum over Monod limitation factors. `sharpness`
 controls the transition through co-limitation; larger values approach the exact
-Liebig minimum. The prepended `one(reference)` is the Frank neutral element for
-limitation factors in `[0, 1]`.
+Liebig minimum. The prepended `one(reference)` is the Frank neutral element.
+The resulting Monod limitation factors must lie in `[0, 1]`.
 """
 @inline function frank_nutrient_limitation(
-    resources::Tuple, half_saturations::Tuple, reference; sharpness=50
+    resources::Tuple, half_saturations::Tuple, reference; sharpness=DEFAULT_FRANK_SHARPNESS
 )
     return nutrient_limitation(
         FrankMinimum(sharpness), monod_limitations(resources, half_saturations), reference

--- a/src/Library/photosynthesis.jl
+++ b/src/Library/photosynthesis.jl
@@ -2,12 +2,12 @@
 
 module Photosynthesis
 
-using ..Nutrients: MonodLimitation, LiebigMinimum, SmoothLiebigMinimum
+using ..Nutrients: MonodLimitation, LiebigMinimum, FrankMinimum
 
 export smith_light_limitation,
     geider_light_limitation,
     liebig_nutrient_limitation,
-    smooth_liebig_nutrient_limitation,
+    frank_nutrient_limitation,
     nutrient_limitation,
     smith_growth,
     geider_growth
@@ -146,20 +146,36 @@ resources.
     end
 end
 
-@inline nutrient_limitation(::Val{:liebig}, limitations::Tuple, reference) = LiebigMinimum()((one(reference), limitations...))
-
-@inline nutrient_limitation(::Val{:smooth_liebig}, limitations::Tuple, reference) = SmoothLiebigMinimum()((one(reference), limitations...))
-
-@inline function liebig_nutrient_limitation(resources::Tuple, half_saturations::Tuple, reference)
-    return nutrient_limitation(Val(:liebig), monod_limitations(resources, half_saturations), reference)
+@inline function nutrient_limitation(
+    limitation::Union{LiebigMinimum,FrankMinimum}, limitations::Tuple, reference
+)
+    return limitation((one(reference), limitations...))
 end
 
-@inline function smooth_liebig_nutrient_limitation(resources::Tuple, half_saturations::Tuple, reference)
-    return nutrient_limitation(Val(:smooth_liebig), monod_limitations(resources, half_saturations), reference)
+@inline function liebig_nutrient_limitation(resources::Tuple, half_saturations::Tuple, reference)
+    return nutrient_limitation(
+        LiebigMinimum(), monod_limitations(resources, half_saturations), reference
+    )
+end
+
+"""
+    frank_nutrient_limitation(resources, half_saturations, reference; sharpness=50)
+
+Compute a differentiable Frank minimum over Monod limitation factors. `sharpness`
+controls the transition through co-limitation; larger values approach the exact
+Liebig minimum. The prepended `one(reference)` is the Frank neutral element for
+limitation factors in `[0, 1]`.
+"""
+@inline function frank_nutrient_limitation(
+    resources::Tuple, half_saturations::Tuple, reference; sharpness=50
+)
+    return nutrient_limitation(
+        FrankMinimum(sharpness), monod_limitations(resources, half_saturations), reference
+    )
 end
 
 @inline function nutrient_limitation(
-    limitation::Val,
+    limitation::Union{LiebigMinimum,FrankMinimum},
     resources::Tuple,
     half_saturations::Tuple,
     reference,
@@ -200,11 +216,13 @@ Compute Smith-style phytoplankton biomass growth with Liebig nutrient limitation
     half_saturations::Tuple,
     alpha,
 )
-    return smith_growth(Val(:liebig), resources, P, PAR, maximum_growth_0C, half_saturations, alpha)
+    return smith_growth(
+        LiebigMinimum(), resources, P, PAR, maximum_growth_0C, half_saturations, alpha
+    )
 end
 
 @inline function smith_growth(
-    limitation::Val,
+    limitation::Union{LiebigMinimum,FrankMinimum},
     resources::Tuple,
     P,
     PAR,
@@ -253,7 +271,7 @@ Compute Geider-style phytoplankton biomass growth with Liebig nutrient limitatio
     chlorophyll_to_carbon_ratio,
 )
     return geider_growth(
-        Val(:liebig),
+        LiebigMinimum(),
         resources,
         P,
         PAR,
@@ -265,7 +283,7 @@ Compute Geider-style phytoplankton biomass growth with Liebig nutrient limitatio
 end
 
 @inline function geider_growth(
-    limitation::Val,
+    limitation::Union{LiebigMinimum,FrankMinimum},
     resources::Tuple,
     P,
     PAR,

--- a/src/Library/photosynthesis.jl
+++ b/src/Library/photosynthesis.jl
@@ -2,7 +2,7 @@
 
 module Photosynthesis
 
-using ..Nutrients: MonodLimitation, LiebigMinimum, FrankMinimum, DEFAULT_FRANK_SHARPNESS
+using ..Nutrients: MonodLimitation, LiebigMinimum, FrankTNorm, DEFAULT_FRANK_SHARPNESS
 
 export smith_light_limitation,
     geider_light_limitation,
@@ -147,7 +147,7 @@ resources.
 end
 
 @inline function nutrient_limitation(
-    limitation::Union{LiebigMinimum,FrankMinimum}, limitations::Tuple, reference
+    limitation::Union{LiebigMinimum,FrankTNorm}, limitations::Tuple, reference
 )
     return limitation((one(reference), limitations...))
 end
@@ -161,21 +161,21 @@ end
 """
     frank_nutrient_limitation(resources, half_saturations, reference; sharpness=50)
 
-Compute a differentiable Frank minimum over Monod limitation factors. `sharpness`
+Compute a differentiable Frank t-norm over Monod limitation factors. `sharpness`
 controls the transition through co-limitation; larger values approach the exact
-Liebig minimum. The prepended `one(reference)` is the Frank neutral element.
+Liebig minimum. The prepended `one(reference)` is the Frank t-norm neutral element.
 The resulting Monod limitation factors must lie in `[0, 1]`.
 """
 @inline function frank_nutrient_limitation(
     resources::Tuple, half_saturations::Tuple, reference; sharpness=DEFAULT_FRANK_SHARPNESS
 )
     return nutrient_limitation(
-        FrankMinimum(sharpness), monod_limitations(resources, half_saturations), reference
+        FrankTNorm(sharpness), monod_limitations(resources, half_saturations), reference
     )
 end
 
 @inline function nutrient_limitation(
-    limitation::Union{LiebigMinimum,FrankMinimum},
+    limitation::Union{LiebigMinimum,FrankTNorm},
     resources::Tuple,
     half_saturations::Tuple,
     reference,
@@ -222,7 +222,7 @@ Compute Smith-style phytoplankton biomass growth with Liebig nutrient limitation
 end
 
 @inline function smith_growth(
-    limitation::Union{LiebigMinimum,FrankMinimum},
+    limitation::Union{LiebigMinimum,FrankTNorm},
     resources::Tuple,
     P,
     PAR,
@@ -283,7 +283,7 @@ Compute Geider-style phytoplankton biomass growth with Liebig nutrient limitatio
 end
 
 @inline function geider_growth(
-    limitation::Union{LiebigMinimum,FrankMinimum},
+    limitation::Union{LiebigMinimum,FrankTNorm},
     resources::Tuple,
     P,
     PAR,

--- a/src/Tendencies/Tendencies.jl
+++ b/src/Tendencies/Tendencies.jl
@@ -3,6 +3,7 @@ module Tendencies
 
 using ..Equations: CompiledEquation
 using ..Library.Mortality: linear_loss, quadratic_loss
+using ..Library.Nutrients: LiebigMinimum, FrankMinimum
 using ..Library.Photosynthesis: smith_growth, geider_growth
 using ..Library.Remineralization: linear_remineralization
 using ..Runtime: tendency_inputs

--- a/src/Tendencies/Tendencies.jl
+++ b/src/Tendencies/Tendencies.jl
@@ -3,7 +3,7 @@ module Tendencies
 
 using ..Equations: CompiledEquation
 using ..Library.Mortality: linear_loss, quadratic_loss
-using ..Library.Nutrients: LiebigMinimum, FrankMinimum
+using ..Library.Nutrients: LiebigMinimum, FrankTNorm
 using ..Library.Photosynthesis: smith_growth, geider_growth
 using ..Library.Remineralization: linear_remineralization
 using ..Runtime: tendency_inputs

--- a/src/Tendencies/config.jl
+++ b/src/Tendencies/config.jl
@@ -13,7 +13,7 @@ function nutrient_limitation_operator(limitation::Symbol)
     return LiebigMinimum()
 end
 
-nutrient_limitation_operator(limitation::Union{LiebigMinimum,FrankMinimum}) = limitation
+nutrient_limitation_operator(limitation::Union{LiebigMinimum,FrankTNorm}) = limitation
 
 function nutrient_limitation_operator(limitation)
     throw(
@@ -34,7 +34,7 @@ Small configuration object used by reusable tendency builders.
 through organic matter. Supported values are `:simple_detritus` and `:dom_pom`.
 `zooplankton` remains a separate selector because grazing formulations can vary
 independently of growth and organic-matter cycling. `nutrient_limitation` accepts
-`:liebig` or a limitation operator such as `FrankMinimum(sharpness)`.
+`:liebig` or a limitation operator such as `FrankTNorm(sharpness)`.
 """
 function TendencyConfig(;
     growth::Symbol,

--- a/src/Tendencies/config.jl
+++ b/src/Tendencies/config.jl
@@ -1,10 +1,26 @@
 const SUPPORTED_GROWTH_FORMULATIONS = (:smith, :geider)
 const SUPPORTED_ORGANIC_CYCLING_FORMULATIONS = (:simple_detritus, :dom_pom)
 const SUPPORTED_ZOOPLANKTON_FORMULATIONS = (:preferential_grazing,)
-const SUPPORTED_NUTRIENT_LIMITATIONS = (:liebig, :smooth_liebig)
 
 struct TendencyConfig{Growth,OrganicCycling,Zooplankton,NutrientLimitation,Nutrients}
+    nutrient_limitation::NutrientLimitation
     nutrients::Nutrients
+end
+
+function nutrient_limitation_operator(limitation::Symbol)
+    limitation === :liebig ||
+        throw(ArgumentError("Unsupported nutrient limitation formulation: $limitation"))
+    return LiebigMinimum()
+end
+
+nutrient_limitation_operator(limitation::Union{LiebigMinimum,FrankMinimum}) = limitation
+
+function nutrient_limitation_operator(limitation)
+    throw(
+        ArgumentError(
+            "Unsupported nutrient limitation operator: $(typeof(limitation))"
+        )
+    )
 end
 
 """
@@ -17,15 +33,14 @@ Small configuration object used by reusable tendency builders.
 `:smith` and `:geider`. `organic_cycling` selects how plankton losses are routed
 through organic matter. Supported values are `:simple_detritus` and `:dom_pom`.
 `zooplankton` remains a separate selector because grazing formulations can vary
-independently of growth and organic-matter cycling. `nutrient_limitation` selects
-how nutrient limitation terms are aggregated by nutrient-coupled growth
-formulations.
+independently of growth and organic-matter cycling. `nutrient_limitation` accepts
+`:liebig` or a limitation operator such as `FrankMinimum(sharpness)`.
 """
 function TendencyConfig(;
     growth::Symbol,
     organic_cycling::Symbol,
     zooplankton::Symbol=:preferential_grazing,
-    nutrient_limitation::Symbol=:liebig,
+    nutrient_limitation=:liebig,
     nutrients::Tuple=(),
 )
     growth in SUPPORTED_GROWTH_FORMULATIONS ||
@@ -34,14 +49,14 @@ function TendencyConfig(;
         throw(ArgumentError("Unsupported organic cycling formulation: $organic_cycling"))
     zooplankton in SUPPORTED_ZOOPLANKTON_FORMULATIONS ||
         throw(ArgumentError("Unsupported zooplankton formulation: $zooplankton"))
-    nutrient_limitation in SUPPORTED_NUTRIENT_LIMITATIONS ||
-        throw(ArgumentError("Unsupported nutrient limitation rule: $nutrient_limitation"))
+
+    limitation = nutrient_limitation_operator(nutrient_limitation)
 
     return TendencyConfig{
         growth,
         organic_cycling,
         zooplankton,
-        nutrient_limitation,
+        typeof(limitation),
         typeof(nutrients),
-    }(nutrients)
+    }(limitation, nutrients)
 end

--- a/src/Tendencies/helpers.jl
+++ b/src/Tendencies/helpers.jl
@@ -47,7 +47,7 @@ end
 
 @inline function plankton_growth(
     ::Val{:smith},
-    limitation::Union{LiebigMinimum,FrankMinimum},
+    limitation::Union{LiebigMinimum,FrankTNorm},
     resources::Tuple,
     P,
     PAR,
@@ -62,7 +62,7 @@ end
 
 @inline function plankton_growth(
     ::Val{:geider},
-    limitation::Union{LiebigMinimum,FrankMinimum},
+    limitation::Union{LiebigMinimum,FrankTNorm},
     resources::Tuple,
     P,
     PAR,

--- a/src/Tendencies/helpers.jl
+++ b/src/Tendencies/helpers.jl
@@ -47,7 +47,7 @@ end
 
 @inline function plankton_growth(
     ::Val{:smith},
-    limitation::Union{Val{:liebig},Val{:smooth_liebig}},
+    limitation::Union{LiebigMinimum,FrankMinimum},
     resources::Tuple,
     P,
     PAR,
@@ -62,7 +62,7 @@ end
 
 @inline function plankton_growth(
     ::Val{:geider},
-    limitation::Union{Val{:liebig},Val{:smooth_liebig}},
+    limitation::Union{LiebigMinimum,FrankMinimum},
     resources::Tuple,
     P,
     PAR,

--- a/src/Tendencies/inorganic.jl
+++ b/src/Tendencies/inorganic.jl
@@ -30,6 +30,7 @@ function inorganic_tendency(
     stoichiometry=nothing,
     export_fraction::Symbol=:mortality_export_fraction,
 ) where {Growth,Zooplankton,Limitation}
+    limitation = config.nutrient_limitation
     nutrients = config.nutrients
     sources, ratio_name = inorganic_target_coupling(
         config, target, remineralization, stoichiometry
@@ -42,7 +43,7 @@ function inorganic_tendency(
         half_saturations = half_saturation_parameters(parameters, nutrients)
         uptake = growth_sum(
             Val(Growth),
-            Val(Limitation),
+            limitation,
             tracer_values.plankton,
             resources,
             tracer_values.PAR,
@@ -75,6 +76,7 @@ function inorganic_tendency(
     remineralization=nothing,
     stoichiometry=nothing,
 ) where {Growth,Zooplankton,Limitation}
+    limitation = config.nutrient_limitation
     nutrients = config.nutrients
     sources, ratio_name = inorganic_target_coupling(
         config, target, remineralization, stoichiometry
@@ -87,7 +89,7 @@ function inorganic_tendency(
         half_saturations = half_saturation_parameters(parameters, nutrients)
         uptake = growth_sum(
             Val(Growth),
-            Val(Limitation),
+            limitation,
             tracer_values.plankton,
             resources,
             tracer_values.PAR,

--- a/src/Tendencies/phytoplankton.jl
+++ b/src/Tendencies/phytoplankton.jl
@@ -2,6 +2,7 @@
 function phytoplankton_tendency(
     config::TendencyConfig{Growth,OrganicCycling,Zooplankton,Limitation}; plankton_idx::Int
 ) where {Growth,OrganicCycling,Zooplankton,Limitation}
+    limitation = config.nutrient_limitation
     nutrients = config.nutrients
 
     f = function (bgc, x, y, z, t, args...)
@@ -15,7 +16,7 @@ function phytoplankton_tendency(
         P = plankton(plankton_idx)
         growth = plankton_growth(
             Val(Growth),
-            Val(Limitation),
+            limitation,
             resources,
             P,
             tracer_values.PAR,

--- a/src/Tendencies/reductions.jl
+++ b/src/Tendencies/reductions.jl
@@ -7,7 +7,7 @@ across model tracer kernels (e.g. NiPiZD and DARWIN).
 module Reductions
 
 using ...Library.Mortality: linear_loss, quadratic_loss
-using ...Library.Nutrients: LiebigMinimum, FrankMinimum
+using ...Library.Nutrients: LiebigMinimum, FrankTNorm
 using ...Library.Photosynthesis: smith_growth, geider_growth
 using ...Library.Predation:
     preferential_predation_loss,
@@ -160,7 +160,7 @@ end
 """Smith growth summed over all plankton classes."""
 function growth_sum(
     ::Val{:smith},
-    limitation::Union{LiebigMinimum,FrankMinimum},
+    limitation::Union{LiebigMinimum,FrankTNorm},
     plankton,
     resources::Tuple,
     PAR,
@@ -181,7 +181,7 @@ end
 """Geider growth summed over all plankton classes."""
 function growth_sum(
     ::Val{:geider},
-    limitation::Union{LiebigMinimum,FrankMinimum},
+    limitation::Union{LiebigMinimum,FrankTNorm},
     plankton,
     resources::Tuple,
     PAR,

--- a/src/Tendencies/reductions.jl
+++ b/src/Tendencies/reductions.jl
@@ -7,6 +7,7 @@ across model tracer kernels (e.g. NiPiZD and DARWIN).
 module Reductions
 
 using ...Library.Mortality: linear_loss, quadratic_loss
+using ...Library.Nutrients: LiebigMinimum, FrankMinimum
 using ...Library.Photosynthesis: smith_growth, geider_growth
 using ...Library.Predation:
     preferential_predation_loss,
@@ -159,7 +160,7 @@ end
 """Smith growth summed over all plankton classes."""
 function growth_sum(
     ::Val{:smith},
-    limitation::Union{Val{:liebig},Val{:smooth_liebig}},
+    limitation::Union{LiebigMinimum,FrankMinimum},
     plankton,
     resources::Tuple,
     PAR,
@@ -180,7 +181,7 @@ end
 """Geider growth summed over all plankton classes."""
 function growth_sum(
     ::Val{:geider},
-    limitation::Union{Val{:liebig},Val{:smooth_liebig}},
+    limitation::Union{LiebigMinimum,FrankMinimum},
     plankton,
     resources::Tuple,
     PAR,

--- a/test/test_library.jl
+++ b/test/test_library.jl
@@ -2,9 +2,10 @@ using Agate
 using Test
 using ForwardDiff
 
-using Agate.Library.Nutrients: liebig_minimum, smooth_liebig_minimum
-using Agate.Library.Photosynthesis: liebig_nutrient_limitation, smooth_liebig_nutrient_limitation
+using Agate.Library.Nutrients: FrankMinimum, frank_minimum, liebig_minimum
+using Agate.Library.Photosynthesis: frank_nutrient_limitation, liebig_nutrient_limitation
 using Agate.Library.Predation: holling_type_ii, idealized_predation_loss
+using Agate.Tendencies: TendencyConfig
 
 @testset "Library" begin
     @test holling_type_ii(1.0, 1.0) == 0.5
@@ -17,13 +18,52 @@ end
     T = Float32
 
     @test Agate.Library.Nutrients.monod_limitation(T(1), T(0.5)) isa T
-    @test Agate.Library.Nutrients.smooth_liebig_minimum(T(0.2), T(0.4)) isa T
-    @test Agate.Library.Photosynthesis.smooth_liebig_nutrient_limitation(
-        (T(1), T(2)), (T(0.5), T(1)), one(T)
+    @test frank_minimum(T(0.2), T(0.4)) isa T
+    @test frank_minimum(T(0.2), T(0.4); sharpness=50.0) isa T
+    @test frank_nutrient_limitation((T(1), T(2)), (T(0.5), T(1)), one(T)) isa T
+    @test frank_nutrient_limitation(
+        (T(1), T(2)), (T(0.5), T(1)), one(T); sharpness=25.0
     ) isa T
     @test Agate.Library.Photosynthesis.smith_light_limitation(T(50), T(0.1), T(1)) isa T
     @test Agate.Library.Mortality.linear_loss(T(1), T(0.1)) isa T
     @test Agate.Library.Predation.holling_type_ii(T(1), T(0.5)) isa T
     @test Agate.Library.Remineralization.linear_remineralization(T(1), T(0.1)) isa T
     @test Agate.Library.Temperature.q10_temperature_factor(T(10), T(2)) isa T
+end
+
+@testset "Frank minimum" begin
+    @test frank_minimum(0.5, 1.0) ≈ 0.5
+    @test frank_minimum(0.0, 0.5) ≈ 0.0
+    @test frank_minimum(1.0, 1.0) ≈ 1.0
+    @test frank_minimum(0.2, 0.8) ≈ frank_minimum(0.8, 0.2)
+    @test frank_minimum((0.2, 1.0, 0.8)) ≈ frank_minimum(0.2, 0.8)
+    @test isnan(frank_minimum(NaN, 0.5))
+
+    low_sharpness = frank_minimum(0.5, 0.5; sharpness=25)
+    high_sharpness = frank_minimum(0.5, 0.5; sharpness=100)
+    @test low_sharpness < high_sharpness < liebig_minimum(0.5, 0.5)
+
+    s = 5.0
+    q = exp(-s)
+    expected = log(1 + ((q^0.3 - 1) * (q^0.7 - 1)) / (q - 1)) / log(q)
+    @test frank_minimum(0.3, 0.7; sharpness=s) ≈ expected
+
+    @test frank_nutrient_limitation((1.0,), (1.0,), 1.0) ≈ 0.5
+
+    gradient = ForwardDiff.gradient(x -> FrankMinimum()(x[1], x[2]), [0.5, 0.5])
+    @test all(isfinite, gradient)
+    @test gradient[1] ≈ gradient[2]
+
+    liebig_config = TendencyConfig(;
+        growth=:smith, organic_cycling=:simple_detritus, nutrient_limitation=:liebig
+    )
+    @test liebig_config.nutrient_limitation isa Agate.Library.Nutrients.LiebigMinimum
+
+    frank_config = TendencyConfig(;
+        growth=:smith,
+        organic_cycling=:simple_detritus,
+        nutrient_limitation=FrankMinimum(25),
+    )
+    @test frank_config.nutrient_limitation isa FrankMinimum
+    @test frank_config.nutrient_limitation.sharpness == 25
 end

--- a/test/test_library.jl
+++ b/test/test_library.jl
@@ -2,7 +2,7 @@ using Agate
 using Test
 using ForwardDiff
 
-using Agate.Library.Nutrients: FrankMinimum, frank_minimum, liebig_minimum
+using Agate.Library.Nutrients: FrankTNorm, frank_tnorm, liebig_minimum
 using Agate.Library.Photosynthesis: frank_nutrient_limitation, liebig_nutrient_limitation
 using Agate.Library.Predation: holling_type_ii, idealized_predation_loss
 using Agate.Tendencies: TendencyConfig, nutrient_coupling, phytoplankton_tendency
@@ -18,8 +18,8 @@ end
     T = Float32
 
     @test Agate.Library.Nutrients.monod_limitation(T(1), T(0.5)) isa T
-    @test frank_minimum(T(0.2), T(0.4)) isa T
-    @test frank_minimum(T(0.2), T(0.4); sharpness=50.0) isa T
+    @test frank_tnorm(T(0.2), T(0.4)) isa T
+    @test frank_tnorm(T(0.2), T(0.4); sharpness=50.0) isa T
     @test frank_nutrient_limitation((T(1), T(2)), (T(0.5), T(1)), one(T)) isa T
     @test frank_nutrient_limitation(
         (T(1), T(2)), (T(0.5), T(1)), one(T); sharpness=25.0
@@ -31,26 +31,26 @@ end
     @test Agate.Library.Temperature.q10_temperature_factor(T(10), T(2)) isa T
 end
 
-@testset "Frank minimum" begin
-    @test frank_minimum(0.5, 1.0) ≈ 0.5
-    @test frank_minimum(0.0, 0.5) ≈ 0.0
-    @test frank_minimum(1.0, 1.0) ≈ 1.0
-    @test frank_minimum(0.2, 0.8) ≈ frank_minimum(0.8, 0.2)
-    @test frank_minimum((0.2, 1.0, 0.8)) ≈ frank_minimum(0.2, 0.8)
-    @test isnan(frank_minimum(NaN, 0.5))
+@testset "Frank t-norm" begin
+    @test frank_tnorm(0.5, 1.0) ≈ 0.5
+    @test frank_tnorm(0.0, 0.5) ≈ 0.0
+    @test frank_tnorm(1.0, 1.0) ≈ 1.0
+    @test frank_tnorm(0.2, 0.8) ≈ frank_tnorm(0.8, 0.2)
+    @test frank_tnorm((0.2, 1.0, 0.8)) ≈ frank_tnorm(0.2, 0.8)
+    @test isnan(frank_tnorm(NaN, 0.5))
 
-    low_sharpness = frank_minimum(0.5, 0.5; sharpness=25)
-    high_sharpness = frank_minimum(0.5, 0.5; sharpness=100)
+    low_sharpness = frank_tnorm(0.5, 0.5; sharpness=25)
+    high_sharpness = frank_tnorm(0.5, 0.5; sharpness=100)
     @test low_sharpness < high_sharpness < liebig_minimum(0.5, 0.5)
 
     s = 5.0
     q = exp(-s)
     expected = log(1 + ((q^0.3 - 1) * (q^0.7 - 1)) / (q - 1)) / log(q)
-    @test frank_minimum(0.3, 0.7; sharpness=s) ≈ expected
+    @test frank_tnorm(0.3, 0.7; sharpness=s) ≈ expected
 
     @test frank_nutrient_limitation((1.0,), (1.0,), 1.0) ≈ 0.5
 
-    gradient = ForwardDiff.gradient(x -> FrankMinimum()(x[1], x[2]), [0.5, 0.5])
+    gradient = ForwardDiff.gradient(x -> FrankTNorm()(x[1], x[2]), [0.5, 0.5])
     @test all(isfinite, gradient)
     @test gradient[1] ≈ gradient[2]
 
@@ -62,17 +62,17 @@ end
     frank_config = TendencyConfig(;
         growth=:smith,
         organic_cycling=:simple_detritus,
-        nutrient_limitation=FrankMinimum(25),
+        nutrient_limitation=FrankTNorm(25),
     )
-    @test frank_config.nutrient_limitation isa FrankMinimum
+    @test frank_config.nutrient_limitation isa FrankTNorm
     @test frank_config.nutrient_limitation.sharpness == 25
 end
 
-@testset "Frank tendency plumbing" begin
+@testset "Frank t-norm tendency plumbing" begin
     config = TendencyConfig(;
         growth=:geider,
         organic_cycling=:dom_pom,
-        nutrient_limitation=FrankMinimum(50),
+        nutrient_limitation=FrankTNorm(50),
         nutrients=(
             nutrient_coupling(
                 :DIN,

--- a/test/test_library.jl
+++ b/test/test_library.jl
@@ -5,7 +5,7 @@ using ForwardDiff
 using Agate.Library.Nutrients: FrankMinimum, frank_minimum, liebig_minimum
 using Agate.Library.Photosynthesis: frank_nutrient_limitation, liebig_nutrient_limitation
 using Agate.Library.Predation: holling_type_ii, idealized_predation_loss
-using Agate.Tendencies: TendencyConfig
+using Agate.Tendencies: TendencyConfig, nutrient_coupling, phytoplankton_tendency
 
 @testset "Library" begin
     @test holling_type_ii(1.0, 1.0) == 0.5
@@ -66,4 +66,58 @@ end
     )
     @test frank_config.nutrient_limitation isa FrankMinimum
     @test frank_config.nutrient_limitation.sharpness == 25
+end
+
+@testset "Frank tendency plumbing" begin
+    config = TendencyConfig(;
+        growth=:geider,
+        organic_cycling=:dom_pom,
+        nutrient_limitation=FrankMinimum(50),
+        nutrients=(
+            nutrient_coupling(
+                :DIN,
+                :half_saturation_DIN;
+                stoichiometry=:nitrogen_to_carbon,
+                remineralization=(
+                    (:DON, :DON_remineralization), (:PON, :PON_remineralization)
+                ),
+            ),
+            nutrient_coupling(
+                :PO4,
+                :half_saturation_PO4;
+                stoichiometry=:phosphorus_to_carbon,
+                remineralization=(
+                    (:DOP, :DOP_remineralization), (:POP, :POP_remineralization)
+                ),
+            ),
+        ),
+    )
+
+    bgc = Agate.Models.DARWIN.construct()
+    frank_tendency = phytoplankton_tendency(config; plankton_idx=3)
+
+    DIN = bgc.parameters.half_saturation_DIN[3]
+    PO4 = bgc.parameters.half_saturation_PO4[3]
+    args = (
+        10.0,
+        DIN,
+        PO4,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.01,
+        0.01,
+        100.0,
+    )
+
+    frank = frank_tendency(bgc, 0, 0, 0, 0, args...)
+    liebig = bgc(Val(:P_1), 0, 0, 0, 0, args...)
+
+    @test isfinite(frank)
+    @test frank < liebig
 end


### PR DESCRIPTION
* Replace `SmoothLiebigMinimum` with `FrankTNorm`, implementing the Frank t-norm as a differentiable alternative to the hard Liebig minimum.
* Replace `smooth_liebig_minimum` with `frank_tnorm`.
* Replace `smooth_liebig_nutrient_limitation` with `frank_nutrient_limitation`.
* `FrankTNorm` preserves the neutral and absorbing boundaries expected for normalized limitation factors: `F(a, 1) = a` and `F(a, 0) = 0`.
* Finite Frank sharpness provides smooth derivatives through co-limitation for automatic differentiation. The default sharpness is `50`.
* The previous unnormalised log-sum-exp formulation could depress limitation near nutrient-replete conditions and produce negative limitation factors near nutrient exhaustion. These behaviours are corrected, so scientific output can change in those regimes.
* Built-in NiPiZD and DARWIN configurations continue to use Liebig limitation. `FrankTNorm` is available through the lower-level tendency configuration for workflows requiring differentiable nutrient limitation.

### Breaking changes

* `SmoothLiebigMinimum` → `FrankTNorm`
* `smooth_liebig_minimum` → `frank_tnorm`
* `smooth_liebig_nutrient_limitation` → `frank_nutrient_limitation`
* `TendencyConfig(nutrient_limitation=:smooth_liebig)` is replaced by an explicit `FrankTNorm(sharpness)` operator for lower-level tendency configuration.
